### PR TITLE
A1 – modular bootstrap + horizon + redis session/cache + perf hooks

### DIFF
--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $routeMiddleware = [
+        'cache.headers' => \App\Http\Middleware\CacheHeaders::class,
+    ];
+}

--- a/src/app/Http/Middleware/CacheHeaders.php
+++ b/src/app/Http/Middleware/CacheHeaders.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class CacheHeaders
+{
+    public function __construct(protected int $maxAge = 60)
+    {
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        if ($request->hasSession() || $request->user()) {
+            return $response;
+        }
+
+        $response->headers->set('Cache-Control', 'public, max-age='.$this->maxAge);
+
+        return $response;
+    }
+}

--- a/src/app/Modules/SharedKernel/Application/Validation/DynamicValidator.php
+++ b/src/app/Modules/SharedKernel/Application/Validation/DynamicValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Modules\SharedKernel\Application\Validation;
+
+class DynamicValidator
+{
+    public static function rules(array $schema): array
+    {
+        $rules = [];
+        foreach ($schema as $field => $rule) {
+            if (is_array($rule)) {
+                $rule = implode('|', $rule);
+            }
+            $rules[$field] = $rule;
+        }
+
+        return $rules;
+    }
+}

--- a/src/app/Modules/SharedKernel/Infrastructure/Support/Idempotency.php
+++ b/src/app/Modules/SharedKernel/Infrastructure/Support/Idempotency.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\SharedKernel\Infrastructure\Support;
+
+trait Idempotency
+{
+    public static function idempotencyKey(array $parts): string
+    {
+        return sha1(implode(':', $parts));
+    }
+}

--- a/src/app/Modules/SharedKernel/Jobs/PingJob.php
+++ b/src/app/Modules/SharedKernel/Jobs/PingJob.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Modules\SharedKernel\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class PingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The name of the queue on which to place the job.
+     *
+     * @var string
+     */
+    public $queue = 'high';
+
+    public function handle(): void
+    {
+        Log::info('PingJob executed');
+    }
+}

--- a/src/app/Modules/SharedKernel/SharedKernelServiceProvider.php
+++ b/src/app/Modules/SharedKernel/SharedKernelServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\SharedKernel;
+
+use Illuminate\Support\ServiceProvider;
+
+class SharedKernelServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        //
+    }
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/routes/web.php');
+    }
+}

--- a/src/app/Modules/SharedKernel/routes/web.php
+++ b/src/app/Modules/SharedKernel/routes/web.php
@@ -1,0 +1,5 @@
+<?php
+use Illuminate\Support\Facades\Route;
+
+Route::get('/_healthz', fn () => response()->json(['ok' => true, 'ts' => now()]))->name('healthz');
+Route::get('/_readyz', fn () => response()->json(['ready' => true]))->name('readyz');

--- a/src/app/Providers/ModulesServiceProvider.php
+++ b/src/app/Providers/ModulesServiceProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+
+class ModulesServiceProvider extends ServiceProvider
+{
+    /**
+     * The discovered modules and their base paths.
+     *
+     * @var array<string, string>
+     */
+    protected array $modules = [];
+
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        $modulesPath = app_path('Modules');
+        if (! is_dir($modulesPath)) {
+            return;
+        }
+
+        foreach (glob($modulesPath.'/*', GLOB_ONLYDIR) as $modulePath) {
+            $name = basename($modulePath);
+
+            if (! config("modules.enabled.$name", true)) {
+                continue;
+            }
+
+            $this->modules[$name] = $modulePath;
+
+            $providerClass = "App\\Modules\\{$name}\\{$name}ServiceProvider";
+            if (class_exists($providerClass)) {
+                $this->app->register($providerClass);
+            }
+        }
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        foreach ($this->modules as $name => $path) {
+            $this->loadModule($name, $path);
+        }
+    }
+
+    /**
+     * Load resources for the given module.
+     */
+    protected function loadModule(string $name, string $modulePath): void
+    {
+        if (is_dir($modulePath.'/Database/Migrations')) {
+            $this->loadMigrationsFrom($modulePath.'/Database/Migrations');
+        }
+
+        if (file_exists($modulePath.'/routes/web.php')) {
+            $this->loadRoutesFrom($modulePath.'/routes/web.php');
+        }
+
+        if (is_dir($modulePath.'/Resources/views')) {
+            $this->loadViewsFrom($modulePath.'/Resources/views', 'module::'.Str::lower($name));
+        }
+
+        if (is_dir($modulePath.'/Config')) {
+            foreach (glob($modulePath.'/Config/*.php') as $configFile) {
+                $configName = pathinfo($configFile, PATHINFO_FILENAME);
+                $this->mergeConfigFrom($configFile, Str::lower($name).'.'.$configName);
+            }
+        }
+    }
+}

--- a/src/bootstrap/app.php
+++ b/src/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'cache.headers' => \App\Http\Middleware\CacheHeaders::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/src/bootstrap/providers.php
+++ b/src/bootstrap/providers.php
@@ -3,4 +3,5 @@
 return [
     App\Providers\AppServiceProvider::class,
     App\Providers\HorizonServiceProvider::class,
+    App\Providers\ModulesServiceProvider::class,
 ];

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -123,4 +123,33 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
+    'providers' => [
+        Illuminate\Auth\AuthServiceProvider::class,
+        Illuminate\Broadcasting\BroadcastServiceProvider::class,
+        Illuminate\Bus\BusServiceProvider::class,
+        Illuminate\Cache\CacheServiceProvider::class,
+        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
+        Illuminate\Cookie\CookieServiceProvider::class,
+        Illuminate\Database\DatabaseServiceProvider::class,
+        Illuminate\Encryption\EncryptionServiceProvider::class,
+        Illuminate\Filesystem\FilesystemServiceProvider::class,
+        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
+        Illuminate\Hashing\HashServiceProvider::class,
+        Illuminate\Mail\MailServiceProvider::class,
+        Illuminate\Notifications\NotificationServiceProvider::class,
+        Illuminate\Pagination\PaginationServiceProvider::class,
+        Illuminate\Pipeline\PipelineServiceProvider::class,
+        Illuminate\Queue\QueueServiceProvider::class,
+        Illuminate\Redis\RedisServiceProvider::class,
+        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
+        Illuminate\Session\SessionServiceProvider::class,
+        Illuminate\Translation\TranslationServiceProvider::class,
+        Illuminate\Validation\ValidationServiceProvider::class,
+        Illuminate\View\ViewServiceProvider::class,
+
+        App\Providers\AppServiceProvider::class,
+        App\Providers\HorizonServiceProvider::class,
+        App\Providers\ModulesServiceProvider::class,
+    ],
+
 ];

--- a/src/config/horizon.php
+++ b/src/config/horizon.php
@@ -167,47 +167,30 @@ return [
     */
 
     'memory_limit' => 64,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Queue Worker Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Here you may define the queue worker settings used by your application
-    | in all environments. These supervisors and settings handle all your
-    | queued jobs and will be provisioned by Horizon during deployment.
-    |
-    */
-
-    'defaults' => [
-        'supervisor-1' => [
+    'supervisors' => [
+        'supervisor-high' => [
+            'connection' => 'redis',
+            'queue' => ['high', 'default'],
+            'balance' => 'auto',
+            'minProcesses' => 2,
+            'maxProcesses' => 4,
+            'tries' => 3,
+        ],
+        'supervisor-default' => [
             'connection' => 'redis',
             'queue' => ['default'],
             'balance' => 'auto',
-            'autoScalingStrategy' => 'time',
-            'maxProcesses' => 1,
-            'maxTime' => 0,
-            'maxJobs' => 0,
-            'memory' => 128,
+            'minProcesses' => 2,
+            'maxProcesses' => 4,
+            'tries' => 3,
+        ],
+        'supervisor-low' => [
+            'connection' => 'redis',
+            'queue' => ['low'],
+            'balance' => 'auto',
+            'minProcesses' => 1,
+            'maxProcesses' => 2,
             'tries' => 1,
-            'timeout' => 60,
-            'nice' => 0,
-        ],
-    ],
-
-    'environments' => [
-        'production' => [
-            'supervisor-1' => [
-                'maxProcesses' => 10,
-                'balanceMaxShift' => 1,
-                'balanceCooldown' => 3,
-            ],
-        ],
-
-        'local' => [
-            'supervisor-1' => [
-                'maxProcesses' => 3,
-            ],
         ],
     ],
 ];

--- a/src/config/modules.php
+++ b/src/config/modules.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    // امکان روشن/خاموش کردن ماژول‌ها در آینده
+    'enabled' => [
+        'SharedKernel' => true,
+        // 'Auth' => true, 'Catalog' => true, ...
+    ],
+];


### PR DESCRIPTION
## Summary
- add dynamic ModulesServiceProvider to auto-discover and boot app modules
- introduce SharedKernel module with health routes, utilities and test job
- configure Horizon supervisors and lightweight cache headers middleware

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6899b53eebe08326bcdd250a03fa107e