### PR TITLE
feat: add OTP login with KYC level1

### DIFF
--- a/src/app/Modules/Auth/Application/Events/UserLoggedIn.php
+++ b/src/app/Modules/Auth/Application/Events/UserLoggedIn.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Modules\Auth\Application\Events;
+
+use App\Models\User;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UserLoggedIn
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public User $user)
+    {
+    }
+}

--- a/src/app/Modules/Auth/Application/Http/Controllers/AuthController.php
+++ b/src/app/Modules/Auth/Application/Http/Controllers/AuthController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Modules\Auth\Application\Http\Controllers;
+
+use App\Models\User;
+use App\Modules\Auth\Application\Events\UserLoggedIn;
+use App\Modules\Auth\Application\Services\OtpService;
+use App\Modules\Auth\Application\Http\Requests\RequestOtpRequest;
+use App\Modules\Auth\Application\Http\Requests\VerifyOtpRequest;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+class AuthController
+{
+    public function __construct(private OtpService $otp)
+    {
+    }
+
+    public function requestOtp(RequestOtpRequest $request)
+    {
+        $this->otp->requestCode($request->input('phone'), $request->ip());
+        return response()->json(['status' => 'ok']);
+    }
+
+    public function verifyOtp(VerifyOtpRequest $request)
+    {
+        $phone = $request->input('phone');
+        $code = $request->input('code');
+        $this->otp->verifyCode($phone, $code, $request->ip());
+        $user = User::where('phone', $phone)->first();
+        if (!$user) {
+            $user = new User();
+            $user->phone = $phone;
+            $user->verification_level = 0;
+            $user->name = $phone;
+            $user->email = $phone.'@example.com';
+            $user->password = bcrypt('secret');
+            $user->save();
+        }
+        Auth::login($user);
+        Event::dispatch(new UserLoggedIn($user));
+        return response()->json(['status' => 'ok', 'redirect' => '/']);
+    }
+
+    public function kycLevel1Form()
+    {
+        return view('authmod::kyc.level1');
+    }
+
+    public function kycLevel1Submit(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'family' => 'required|string',
+            'national_code' => 'required|string',
+        ]);
+        DB::table('kyc_profiles')->updateOrInsert(
+            ['user_id' => $request->user()->id, 'level' => 1],
+            [
+                'status' => 'pending',
+                'data_json' => json_encode($data),
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]
+        );
+        return redirect('/');
+    }
+}

--- a/src/app/Modules/Auth/Application/Http/Requests/RequestOtpRequest.php
+++ b/src/app/Modules/Auth/Application/Http/Requests/RequestOtpRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Modules\Auth\Application\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RequestOtpRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'phone' => ['required', 'regex:/^(\+98|0)?9\d{9}$/'],
+        ];
+    }
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+}

--- a/src/app/Modules/Auth/Application/Http/Requests/VerifyOtpRequest.php
+++ b/src/app/Modules/Auth/Application/Http/Requests/VerifyOtpRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Modules\Auth\Application\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class VerifyOtpRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'phone' => ['required', 'regex:/^(\+98|0)?9\d{9}$/'],
+            'code' => ['required', 'digits_between:4,6'],
+        ];
+    }
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+}

--- a/src/app/Modules/Auth/Application/Jobs/SendOtpSms.php
+++ b/src/app/Modules/Auth/Application/Jobs/SendOtpSms.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\Auth\Application\Jobs;
+
+use App\Modules\Auth\Domain\Contracts\SmsProviderInterface;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SendOtpSms implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $phone, public string $code)
+    {
+    }
+
+    public function handle(SmsProviderInterface $provider): void
+    {
+        $provider->sendCode($this->phone, $this->code);
+    }
+}

--- a/src/app/Modules/Auth/Application/Services/OtpService.php
+++ b/src/app/Modules/Auth/Application/Services/OtpService.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Modules\Auth\Application\Services;
+
+use App\Modules\Auth\Domain\Contracts\OtpStoreInterface;
+use App\Modules\Auth\Application\Jobs\SendOtpSms;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Validation\ValidationException;
+
+class OtpService
+{
+    public function __construct(private OtpStoreInterface $store)
+    {
+    }
+
+    private function normalize(string $phone): ?string
+    {
+        $digits = preg_replace('/[^0-9]/', '', $phone);
+        if (str_starts_with($digits, '98')) {
+            $digits = substr($digits, 2);
+        }
+        if (strlen($digits) === 10 && $digits[0] === '9') {
+            return '0'.$digits;
+        }
+        if (strlen($digits) === 11 && str_starts_with($digits, '09')) {
+            return $digits;
+        }
+        return null;
+    }
+
+    public function requestCode(string $phone, string $ip): void
+    {
+        $phone = $this->normalize($phone);
+        if (!$phone) {
+            throw ValidationException::withMessages(['phone' => ['invalid phone']]);
+        }
+        if (!$this->store->canSend($phone, $ip)) {
+            abort(429, 'Too Many Requests');
+        }
+        $code = (string)random_int(100000, 999999);
+        $hash = hash('sha256', $code.config('app.key'));
+        $this->store->put($phone, $hash, 300);
+        $this->store->markSent($phone, $ip);
+        Bus::dispatch((new SendOtpSms($phone, $code))->onQueue('high'));
+    }
+
+    public function verifyCode(string $phone, string $code, string $ip): bool
+    {
+        $phone = $this->normalize($phone);
+        if (!$phone) {
+            throw ValidationException::withMessages(['phone' => ['invalid phone']]);
+        }
+        $record = $this->store->get($phone);
+        if (!$record) {
+            throw ValidationException::withMessages(['code' => ['not found']]);
+        }
+        if ($record['locked_until']) {
+            throw ValidationException::withMessages(['phone' => ['locked']]);
+        }
+        $hash = hash('sha256', $code.config('app.key'));
+        if (!hash_equals($record['code'] ?? '', $hash)) {
+            $attempts = $this->store->incrAttempts($phone);
+            if ($attempts >= 5) {
+                $this->store->lock($phone, 600);
+            }
+            throw ValidationException::withMessages(['code' => ['invalid']]);
+        }
+        $this->store->delete($phone);
+        return true;
+    }
+}

--- a/src/app/Modules/Auth/AuthServiceProvider.php
+++ b/src/app/Modules/Auth/AuthServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Modules\Auth;
+
+use App\Modules\Auth\Domain\Contracts\OtpStoreInterface;
+use App\Modules\Auth\Domain\Contracts\SmsProviderInterface;
+use App\Modules\Auth\Infrastructure\Otp\RedisOtpStore;
+use App\Modules\Auth\Infrastructure\Sms\DummySmsProvider;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(SmsProviderInterface::class, DummySmsProvider::class);
+        $this->app->bind(OtpStoreInterface::class, RedisOtpStore::class);
+    }
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/routes/web.php');
+        $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
+        $this->loadViewsFrom(__DIR__.'/Resources/views', 'authmod');
+
+        RateLimiter::for('otp-request', function (Request $request) {
+            $phone = $request->input('phone', '');
+            return [
+                Limit::perMinutes(5, 3)->by('phone:'.$phone),
+                Limit::perMinute(5)->by('ip:'.$request->ip()),
+            ];
+        });
+    }
+}

--- a/src/app/Modules/Auth/Database/Migrations/2025_08_11_120000_alter_users_add_auth_columns.php
+++ b/src/app/Modules/Auth/Database/Migrations/2025_08_11_120000_alter_users_add_auth_columns.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('phone')->unique()->nullable();
+            $table->tinyInteger('verification_level')->default(0);
+            $table->string('national_code')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['phone', 'verification_level', 'national_code']);
+        });
+    }
+};

--- a/src/app/Modules/Auth/Database/Migrations/2025_08_11_120100_create_kyc_profiles_table.php
+++ b/src/app/Modules/Auth/Database/Migrations/2025_08_11_120100_create_kyc_profiles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('kyc_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->tinyInteger('level');
+            $table->enum('status', ['pending','approved','rejected'])->default('pending');
+            $table->json('data_json')->nullable();
+            $table->foreignId('reviewed_by')->nullable();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamps();
+            $table->index(['user_id','status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('kyc_profiles');
+    }
+};

--- a/src/app/Modules/Auth/Domain/Contracts/OtpStoreInterface.php
+++ b/src/app/Modules/Auth/Domain/Contracts/OtpStoreInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Modules\Auth\Domain\Contracts;
+
+interface OtpStoreInterface
+{
+    public function put(string $phone, string $codeHash, int $ttlSeconds): void;
+
+    /**
+     * @return array{code?:string,exp?:int,attempts?:int,locked_until?:?int}|null
+     */
+    public function get(string $phone): ?array;
+
+    public function incrAttempts(string $phone): int;
+
+    public function lock(string $phone, int $seconds): void;
+
+    public function canSend(string $phone, string $ip): bool;
+
+    public function markSent(string $phone, string $ip): void;
+
+    public function delete(string $phone): void;
+}

--- a/src/app/Modules/Auth/Domain/Contracts/SmsProviderInterface.php
+++ b/src/app/Modules/Auth/Domain/Contracts/SmsProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Modules\Auth\Domain\Contracts;
+
+interface SmsProviderInterface
+{
+    public function sendCode(string $phone, string $code): void;
+}

--- a/src/app/Modules/Auth/Infrastructure/Otp/RedisOtpStore.php
+++ b/src/app/Modules/Auth/Infrastructure/Otp/RedisOtpStore.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Modules\Auth\Infrastructure\Otp;
+
+use App\Modules\Auth\Domain\Contracts\OtpStoreInterface;
+use Illuminate\Support\Facades\Cache;
+
+class RedisOtpStore implements OtpStoreInterface
+{
+    private function otpKey(string $phone): string
+    {
+        return 'otp:'.$phone;
+    }
+
+    public function put(string $phone, string $codeHash, int $ttlSeconds): void
+    {
+        $data = [
+            'code' => $codeHash,
+            'exp' => time() + $ttlSeconds,
+            'attempts' => 0,
+        ];
+        Cache::put($this->otpKey($phone), $data, $ttlSeconds);
+    }
+
+    public function get(string $phone): ?array
+    {
+        $data = Cache::get($this->otpKey($phone));
+        if (!$data) {
+            return null;
+        }
+        $lockExp = Cache::get('otp:lock:'.$phone);
+        $data['locked_until'] = $lockExp ? $lockExp : null;
+        return $data;
+    }
+
+    public function incrAttempts(string $phone): int
+    {
+        $data = Cache::get($this->otpKey($phone));
+        if (!$data) {
+            return 0;
+        }
+        $data['attempts'] = ($data['attempts'] ?? 0) + 1;
+        $ttl = max(0, $data['exp'] - time());
+        Cache::put($this->otpKey($phone), $data, $ttl);
+        return $data['attempts'];
+    }
+
+    public function lock(string $phone, int $seconds): void
+    {
+        Cache::put('otp:lock:'.$phone, time() + $seconds, $seconds);
+    }
+
+    public function canSend(string $phone, string $ip): bool
+    {
+        $p = Cache::get('otp:sent:phone:'.$phone, 0);
+        $i = Cache::get('otp:sent:ip:'.$ip, 0);
+        return $p < 3 && $i < 5;
+    }
+
+    public function markSent(string $phone, string $ip): void
+    {
+        Cache::increment('otp:sent:phone:'.$phone);
+        Cache::put('otp:sent:phone:'.$phone, Cache::get('otp:sent:phone:'.$phone), 300);
+        Cache::increment('otp:sent:ip:'.$ip);
+        Cache::put('otp:sent:ip:'.$ip, Cache::get('otp:sent:ip:'.$ip), 60);
+    }
+
+    public function delete(string $phone): void
+    {
+        Cache::forget($this->otpKey($phone));
+        Cache::forget('otp:lock:'.$phone);
+    }
+}

--- a/src/app/Modules/Auth/Infrastructure/Sms/DummySmsProvider.php
+++ b/src/app/Modules/Auth/Infrastructure/Sms/DummySmsProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Modules\Auth\Infrastructure\Sms;
+
+use App\Modules\Auth\Domain\Contracts\SmsProviderInterface;
+use Illuminate\Support\Facades\Log;
+
+class DummySmsProvider implements SmsProviderInterface
+{
+    public function sendCode(string $phone, string $code): void
+    {
+        $masked = substr($phone, 0, 4).'****'.substr($phone, -2);
+        Log::info('SMS to '.$masked.' code: '.$code);
+    }
+}

--- a/src/app/Modules/Auth/Resources/views/auth/login.blade.php
+++ b/src/app/Modules/Auth/Resources/views/auth/login.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-md mx-auto mt-10">
+    <h1 class="text-xl mb-4">Login</h1>
+    <form method="POST" action="{{ route('auth.request_otp') }}" class="mb-6">
+        @csrf
+        <label class="block mb-2">Phone</label>
+        <input type="text" name="phone" class="border p-2 w-full" />
+        @error('phone')<div class="text-red-500 text-sm">{{ $message }}</div>@enderror
+        <button class="mt-2 bg-blue-500 text-white px-4 py-2">Send OTP</button>
+    </form>
+    <form method="POST" action="{{ route('auth.verify_otp') }}">
+        @csrf
+        <label class="block mb-2">Phone</label>
+        <input type="text" name="phone" class="border p-2 w-full" />
+        <label class="block mb-2 mt-4">Code</label>
+        <input type="text" name="code" class="border p-2 w-full" />
+        @error('code')<div class="text-red-500 text-sm">{{ $message }}</div>@enderror
+        <button class="mt-2 bg-green-500 text-white px-4 py-2">Verify</button>
+    </form>
+</div>
+@endsection

--- a/src/app/Modules/Auth/Resources/views/kyc/level1.blade.php
+++ b/src/app/Modules/Auth/Resources/views/kyc/level1.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-md mx-auto mt-10">
+    <h1 class="text-xl mb-4">KYC Level 1</h1>
+    <form method="POST" action="{{ route('kyc.l1.submit') }}">
+        @csrf
+        <label class="block mb-2">Name</label>
+        <input type="text" name="name" class="border p-2 w-full" />
+        <label class="block mb-2 mt-4">Family</label>
+        <input type="text" name="family" class="border p-2 w-full" />
+        <label class="block mb-2 mt-4">National Code</label>
+        <input type="text" name="national_code" class="border p-2 w-full" />
+        <button class="mt-4 bg-blue-500 text-white px-4 py-2">Submit</button>
+    </form>
+</div>
+@endsection

--- a/src/app/Modules/Auth/routes/web.php
+++ b/src/app/Modules/Auth/routes/web.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Modules\Auth\Application\Http\Controllers\AuthController;
+
+Route::middleware('web')->group(function () {
+
+    Route::view('/login', 'authmod::auth.login')->name('auth.login');
+
+    Route::post('/auth/request-otp', [AuthController::class, 'requestOtp'])
+        ->middleware('throttle:otp-request')
+        ->name('auth.request_otp');
+    Route::post('/auth/verify-otp', [AuthController::class, 'verifyOtp'])->name('auth.verify_otp');
+
+    Route::middleware('auth')->group(function () {
+        Route::get('/kyc/level-1', [AuthController::class, 'kycLevel1Form'])->name('kyc.l1.form');
+        Route::post('/kyc/level-1', [AuthController::class, 'kycLevel1Submit'])->name('kyc.l1.submit');
+    });
+});

--- a/src/tests/Feature/Auth/OtpTest.php
+++ b/src/tests/Feature/Auth/OtpTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use App\Modules\Auth\Application\Jobs\SendOtpSms;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class OtpTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::clear();
+    }
+
+    private function getCodeFromQueue(): string
+    {
+        $pushed = Queue::pushed(SendOtpSms::class);
+        return $pushed[0]->code;
+    }
+
+    public function test_request_otp_dispatches_job(): void
+    {
+        Queue::fake();
+        $res = $this->postJson('/auth/request-otp', ['phone' => '09120000000']);
+        $res->assertStatus(200);
+        Queue::assertPushed(SendOtpSms::class, 1);
+    }
+
+    public function test_throttle_phone_ip(): void
+    {
+        Queue::fake();
+        for ($i = 0; $i < 3; $i++) {
+            $this->postJson('/auth/request-otp', ['phone' => '09120000000']);
+        }
+        $res = $this->postJson('/auth/request-otp', ['phone' => '09120000000']);
+        $res->assertStatus(429);
+    }
+
+    public function test_verify_wrong_code_and_lockout(): void
+    {
+        Queue::fake();
+        $this->postJson('/auth/request-otp', ['phone' => '09120000000']);
+        for ($i = 0; $i < 5; $i++) {
+            $resp = $this->postJson('/auth/verify-otp', ['phone' => '09120000000', 'code' => '000000']);
+            $resp->assertStatus(422);
+        }
+        $resp = $this->postJson('/auth/verify-otp', ['phone' => '09120000000', 'code' => '000000']);
+        $resp->assertStatus(422);
+    }
+
+    public function test_verify_success_creates_user_and_login(): void
+    {
+        Queue::fake();
+        $this->postJson('/auth/request-otp', ['phone' => '09120000000']);
+        $code = $this->getCodeFromQueue();
+        $res = $this->postJson('/auth/verify-otp', ['phone' => '09120000000', 'code' => $code]);
+        $res->assertStatus(200);
+        $this->assertDatabaseHas('users', ['phone' => '09120000000']);
+        $this->assertAuthenticated();
+    }
+
+    public function test_existing_user_login_without_duplicate(): void
+    {
+        $user = User::factory()->create();
+        $user->phone = '09120000000';
+        $user->save();
+        Queue::fake();
+        $this->postJson('/auth/request-otp', ['phone' => '09120000000']);
+        $code = $this->getCodeFromQueue();
+        $this->postJson('/auth/verify-otp', ['phone' => '09120000000', 'code' => $code])->assertStatus(200);
+        $this->assertEquals(1, User::where('phone', '09120000000')->count());
+    }
+
+    public function test_kyc_level1_submit_creates_pending_record(): void
+    {
+        Queue::fake();
+        $this->postJson('/auth/request-otp', ['phone' => '09120000000']);
+        $code = $this->getCodeFromQueue();
+        $this->postJson('/auth/verify-otp', ['phone' => '09120000000', 'code' => $code])->assertStatus(200);
+        $res = $this->post('/kyc/level-1', [
+            'name' => 'Ali',
+            'family' => 'Reza',
+            'national_code' => '1234567890',
+        ]);
+        $res->assertRedirect('/');
+        $this->assertDatabaseHas('kyc_profiles', [
+            'user_id' => auth()->id(),
+            'status' => 'pending',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add modular OTP auth service with SMS sending and rate limits
- support KYC level1 profile submission
- cover login, throttling and KYC with feature tests

## Testing
- `php artisan migrate:fresh --force`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6899d6bef4b4832686ae1f55fc4c16fd