### PR TITLE
feat: add rates and orders modules with quote engine

### DIFF
--- a/src/app/Modules/Orders/Application/DTOs/CreateOrderInput.php
+++ b/src/app/Modules/Orders/Application/DTOs/CreateOrderInput.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Modules\Orders\Application\DTOs;
+
+class CreateOrderInput
+{
+    /**
+     * @param array<string,mixed>|null $meta
+     */
+    public function __construct(
+        public int $userId,
+        public string $serviceKey,
+        public string $amountUsd,
+        public ?array $meta = null,
+    ) {}
+}

--- a/src/app/Modules/Orders/Application/DTOs/OrderView.php
+++ b/src/app/Modules/Orders/Application/DTOs/OrderView.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Modules\Orders\Application\DTOs;
+
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+
+class OrderView
+{
+    /**
+     * @param array<string,mixed> $quoteBreakdown
+     */
+    public function __construct(
+        public int $id,
+        public string $serviceKey,
+        public OrderStatus $status,
+        public string $totalIrr,
+        public array $quoteBreakdown,
+    ) {}
+}

--- a/src/app/Modules/Orders/Application/UseCases/CreateOrder.php
+++ b/src/app/Modules/Orders/Application/UseCases/CreateOrder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Modules\Orders\Application\UseCases;
+
+use App\Modules\Orders\Application\DTOs\CreateOrderInput;
+use App\Modules\Orders\Application\DTOs\OrderView;
+use App\Modules\Orders\Domain\Entities\Order;
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+use App\Modules\Rates\Application\DTOs\QuoteInput;
+use App\Modules\Rates\Application\UseCases\CalculateQuote;
+
+class CreateOrder
+{
+    public function __construct(
+        private OrderRepositoryInterface $orders,
+        private CalculateQuote $calculateQuote,
+    ) {}
+
+    public function __invoke(CreateOrderInput $input): OrderView
+    {
+        $quote = ($this->calculateQuote)(new QuoteInput($input->serviceKey, $input->amountUsd));
+
+        $order = new Order(
+            $input->userId,
+            $input->serviceKey,
+            $quote->amountUsd,
+            $quote->feeUsd,
+            $quote->subtotalUsd,
+            $quote->rateUsed,
+            $quote->totalIrr,
+            OrderStatus::Pending,
+            $input->meta,
+            [
+                'amount_usd' => $quote->amountUsd,
+                'fee_usd' => $quote->feeUsd,
+                'subtotal_usd' => $quote->subtotalUsd,
+                'rate_used' => $quote->rateUsed,
+                'total_irr' => $quote->totalIrr,
+            ],
+        );
+
+        $created = $this->orders->create($order);
+
+        return new OrderView(
+            $created->id ?? 0,
+            $created->serviceKey,
+            $created->status,
+            $created->totalIrr,
+            $created->quoteBreakdown,
+        );
+    }
+}

--- a/src/app/Modules/Orders/Application/UseCases/GetOrder.php
+++ b/src/app/Modules/Orders/Application/UseCases/GetOrder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Modules\Orders\Application\UseCases;
+
+use App\Modules\Orders\Application\DTOs\OrderView;
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+
+class GetOrder
+{
+    public function __construct(private OrderRepositoryInterface $orders) {}
+
+    public function __invoke(int $id): ?OrderView
+    {
+        $order = $this->orders->find($id);
+        if (! $order) {
+            return null;
+        }
+
+        return new OrderView(
+            $order->id ?? 0,
+            $order->serviceKey,
+            $order->status,
+            $order->totalIrr,
+            $order->quoteBreakdown,
+        );
+    }
+}

--- a/src/app/Modules/Orders/Application/Views/admin/orders/index.blade.php
+++ b/src/app/Modules/Orders/Application/Views/admin/orders/index.blade.php
@@ -1,0 +1,1 @@
+<div>Orders list</div>

--- a/src/app/Modules/Orders/Application/Views/admin/orders/show.blade.php
+++ b/src/app/Modules/Orders/Application/Views/admin/orders/show.blade.php
@@ -1,0 +1,1 @@
+<div>Order details</div>

--- a/src/app/Modules/Orders/Domain/Entities/Order.php
+++ b/src/app/Modules/Orders/Domain/Entities/Order.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Modules\Orders\Domain\Entities;
+
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+
+class Order
+{
+    /**
+     * @param array<string,mixed>|null $meta
+     * @param array<string,mixed> $quoteBreakdown
+     */
+    public function __construct(
+        public int $userId,
+        public string $serviceKey,
+        public string $amountUsd,
+        public string $feeUsd,
+        public string $subtotalUsd,
+        public string $rateUsed,
+        public string $totalIrr,
+        public OrderStatus $status,
+        public ?array $meta,
+        public array $quoteBreakdown,
+        public ?int $id = null,
+    ) {}
+}

--- a/src/app/Modules/Orders/Domain/Entities/OrderItem.php
+++ b/src/app/Modules/Orders/Domain/Entities/OrderItem.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Modules\Orders\Domain\Entities;
+
+class OrderItem
+{
+    /**
+     * @param array<string,mixed>|null $meta
+     */
+    public function __construct(
+        public ?int $orderId,
+        public ?string $sku,
+        public string $title,
+        public string $unitPriceUsd,
+        public int $qty,
+        public string $lineTotalUsd,
+        public ?array $meta = null,
+    ) {}
+}

--- a/src/app/Modules/Orders/Domain/Enums/OrderStatus.php
+++ b/src/app/Modules/Orders/Domain/Enums/OrderStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Orders\Domain\Enums;
+
+enum OrderStatus: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Processing = 'processing';
+    case Done = 'done';
+    case Refunded = 'refunded';
+    case Failed = 'failed';
+}

--- a/src/app/Modules/Orders/Domain/Repositories/OrderRepositoryInterface.php
+++ b/src/app/Modules/Orders/Domain/Repositories/OrderRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Modules\Orders\Domain\Repositories;
+
+use App\Modules\Orders\Domain\Entities\Order;
+
+interface OrderRepositoryInterface
+{
+    public function create(Order $order): Order;
+
+    public function find(int $id): ?Order;
+}

--- a/src/app/Modules/Orders/Http/Controllers/Admin/OrderController.php
+++ b/src/app/Modules/Orders/Http/Controllers/Admin/OrderController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Orders\Http\Controllers\Admin;
+
+use Illuminate\Routing\Controller;
+
+class OrderController extends Controller
+{
+    public function index()
+    {
+        return view('orders::admin.orders.index');
+    }
+
+    public function show()
+    {
+        return view('orders::admin.orders.show');
+    }
+}

--- a/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Models/OrderItemModel.php
+++ b/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Models/OrderItemModel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Orders\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OrderItemModel extends Model
+{
+    protected $table = 'order_items';
+
+    protected $fillable = [
+        'order_id','sku','title','unit_price_usd','qty','line_total_usd','meta',
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
+}

--- a/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Models/OrderModel.php
+++ b/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Models/OrderModel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Modules\Orders\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OrderModel extends Model
+{
+    protected $table = 'orders';
+
+    protected $fillable = [
+        'user_id','service_key','currency','amount_usd','fee_usd','subtotal_usd','rate_used','total_irr','meta','quote_breakdown','status',
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+        'quote_breakdown' => 'array',
+    ];
+}

--- a/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Repositories/OrderRepository.php
+++ b/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Repositories/OrderRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Modules\Orders\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Modules\Orders\Domain\Entities\Order;
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+use App\Modules\Orders\Infrastructure\Persistence\Eloquent\Models\OrderModel;
+
+class OrderRepository implements OrderRepositoryInterface
+{
+    public function create(Order $order): Order
+    {
+        $model = OrderModel::create([
+            'user_id' => $order->userId,
+            'service_key' => $order->serviceKey,
+            'currency' => 'USD',
+            'amount_usd' => $order->amountUsd,
+            'fee_usd' => $order->feeUsd,
+            'subtotal_usd' => $order->subtotalUsd,
+            'rate_used' => $order->rateUsed,
+            'total_irr' => $order->totalIrr,
+            'meta' => $order->meta,
+            'quote_breakdown' => $order->quoteBreakdown,
+            'status' => $order->status->value,
+        ]);
+
+        return $this->toDomain($model);
+    }
+
+    public function find(int $id): ?Order
+    {
+        $model = OrderModel::find($id);
+        return $model ? $this->toDomain($model) : null;
+    }
+
+    protected function toDomain(OrderModel $model): Order
+    {
+        return new Order(
+            $model->user_id,
+            $model->service_key,
+            (string) $model->amount_usd,
+            (string) $model->fee_usd,
+            (string) $model->subtotal_usd,
+            (string) $model->rate_used,
+            (string) $model->total_irr,
+            OrderStatus::from($model->status),
+            $model->meta,
+            $model->quote_breakdown,
+            $model->id,
+        );
+    }
+}

--- a/src/app/Modules/Orders/OrdersServiceProvider.php
+++ b/src/app/Modules/Orders/OrdersServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Modules\Orders;
+
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+use App\Modules\Orders\Infrastructure\Persistence\Eloquent\Repositories\OrderRepository;
+use Illuminate\Support\ServiceProvider;
+
+class OrdersServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(OrderRepositoryInterface::class, OrderRepository::class);
+    }
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/routes/web.php');
+        $this->loadViewsFrom(__DIR__.'/Application/Views', 'orders');
+    }
+}

--- a/src/app/Modules/Orders/routes/web.php
+++ b/src/app/Modules/Orders/routes/web.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Modules\Orders\Http\Controllers\Admin\OrderController;
+
+Route::middleware(['web','auth'])
+    ->prefix('admin/orders')
+    ->group(function(){
+        Route::get('/', [OrderController::class, 'index'])->name('admin.orders.index');
+        Route::get('/{order}', [OrderController::class, 'show'])->name('admin.orders.show');
+    });

--- a/src/app/Modules/Rates/Application/DTOs/QuoteInput.php
+++ b/src/app/Modules/Rates/Application/DTOs/QuoteInput.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Rates\Application\DTOs;
+
+class QuoteInput
+{
+    public function __construct(
+        public string $serviceKey,
+        public string $amountUsd,
+    ) {}
+}

--- a/src/app/Modules/Rates/Application/DTOs/QuoteResult.php
+++ b/src/app/Modules/Rates/Application/DTOs/QuoteResult.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Rates\Application\DTOs;
+
+class QuoteResult
+{
+    public function __construct(
+        public string $amountUsd,
+        public string $feeUsd,
+        public string $subtotalUsd,
+        public string $rateUsed,
+        public string $totalIrr,
+    ) {}
+}

--- a/src/app/Modules/Rates/Application/UseCases/UpsertFeeRule.php
+++ b/src/app/Modules/Rates/Application/UseCases/UpsertFeeRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\Rates\Application\UseCases;
+
+use App\Modules\Rates\Domain\Entities\FeeRule;
+use App\Modules\Rates\Domain\Enums\FeeType;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+
+class UpsertFeeRule
+{
+    public function __construct(private FeeRuleRepositoryInterface $rules) {}
+
+    public function __invoke(
+        string $serviceKey,
+        string $fromAmount,
+        string $toAmount,
+        FeeType $feeType,
+        string $value,
+        bool $isActive = true,
+    ): FeeRule {
+        $rule = new FeeRule($serviceKey, $fromAmount, $toAmount, $feeType, $value, $isActive);
+        return $this->rules->upsert($rule);
+    }
+}

--- a/src/app/Modules/Rates/Application/UseCases/UpsertRate.php
+++ b/src/app/Modules/Rates/Application/UseCases/UpsertRate.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Modules\Rates\Application\UseCases;
+
+use App\Modules\Rates\Domain\Entities\Rate;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+
+class UpsertRate
+{
+    public function __construct(private RateRepositoryInterface $rates) {}
+
+    public function __invoke(string $usdBuy, string $usdSell, string $baseCurrency = 'IRR'): Rate
+    {
+        $rate = new Rate($baseCurrency, $usdBuy, $usdSell);
+        return $this->rates->upsert($rate);
+    }
+}

--- a/src/app/Modules/Rates/Application/Views/admin/fees/index.blade.php
+++ b/src/app/Modules/Rates/Application/Views/admin/fees/index.blade.php
@@ -1,0 +1,1 @@
+<div>Fee rules panel</div>

--- a/src/app/Modules/Rates/Application/Views/admin/quote/tester.blade.php
+++ b/src/app/Modules/Rates/Application/Views/admin/quote/tester.blade.php
@@ -1,0 +1,1 @@
+<div>Quote tester</div>

--- a/src/app/Modules/Rates/Application/Views/admin/rates/index.blade.php
+++ b/src/app/Modules/Rates/Application/Views/admin/rates/index.blade.php
@@ -1,0 +1,1 @@
+<div>Rates panel</div>

--- a/src/app/Modules/Rates/Domain/Entities/FeeRule.php
+++ b/src/app/Modules/Rates/Domain/Entities/FeeRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Entities;
+
+use App\Modules\Rates\Domain\Enums\FeeType;
+
+class FeeRule
+{
+    public function __construct(
+        public string $serviceKey,
+        public string $fromAmount,
+        public string $toAmount,
+        public FeeType $feeType,
+        public string $value,
+        public bool $isActive = true,
+    ) {}
+
+    public function matches(string $amountUsd): bool
+    {
+        return $this->isActive
+            && bccomp($amountUsd, $this->fromAmount, 2) >= 0
+            && bccomp($amountUsd, $this->toAmount, 2) <= 0;
+    }
+}

--- a/src/app/Modules/Rates/Domain/Entities/Rate.php
+++ b/src/app/Modules/Rates/Domain/Entities/Rate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Entities;
+
+use Carbon\CarbonImmutable;
+
+class Rate
+{
+    public function __construct(
+        public string $baseCurrency,
+        public string $usdBuy,
+        public string $usdSell,
+        public ?CarbonImmutable $updatedAt = null,
+    ) {}
+}

--- a/src/app/Modules/Rates/Domain/Enums/FeeType.php
+++ b/src/app/Modules/Rates/Domain/Enums/FeeType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Enums;
+
+enum FeeType: string
+{
+    case Fixed = 'fixed';
+    case Percent = 'percent';
+}

--- a/src/app/Modules/Rates/Domain/Repositories/FeeRuleRepositoryInterface.php
+++ b/src/app/Modules/Rates/Domain/Repositories/FeeRuleRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Repositories;
+
+use App\Modules\Rates\Domain\Entities\FeeRule;
+
+interface FeeRuleRepositoryInterface
+{
+    /**
+     * @return array<FeeRule>
+     */
+    public function forService(string $serviceKey): array;
+
+    public function upsert(FeeRule $rule): FeeRule;
+}

--- a/src/app/Modules/Rates/Domain/Repositories/RateRepositoryInterface.php
+++ b/src/app/Modules/Rates/Domain/Repositories/RateRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Repositories;
+
+use App\Modules\Rates\Domain\Entities\Rate;
+
+interface RateRepositoryInterface
+{
+    public function latest(): ?Rate;
+
+    public function upsert(Rate $rate): Rate;
+}

--- a/src/app/Modules/Rates/Domain/Services/FeeEngineInterface.php
+++ b/src/app/Modules/Rates/Domain/Services/FeeEngineInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Services;
+
+interface FeeEngineInterface
+{
+    public function compute(string $serviceKey, string $amountUsd): string;
+}

--- a/src/app/Modules/Rates/Domain/ValueObjects/Fee.php
+++ b/src/app/Modules/Rates/Domain/ValueObjects/Fee.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Rates\Domain\ValueObjects;
+
+use App\Modules\Rates\Domain\Enums\FeeType;
+
+class Fee
+{
+    public function __construct(
+        public FeeType $type,
+        public string $value,
+    ) {}
+}

--- a/src/app/Modules/Rates/Http/Controllers/Admin/FeeRuleController.php
+++ b/src/app/Modules/Rates/Http/Controllers/Admin/FeeRuleController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Rates\Http\Controllers\Admin;
+
+use Illuminate\Routing\Controller;
+
+class FeeRuleController extends Controller
+{
+    public function index()
+    {
+        return view('rates::admin.fees.index');
+    }
+}

--- a/src/app/Modules/Rates/Http/Controllers/Admin/RateController.php
+++ b/src/app/Modules/Rates/Http/Controllers/Admin/RateController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Rates\Http\Controllers\Admin;
+
+use Illuminate\Routing\Controller;
+
+class RateController extends Controller
+{
+    public function index()
+    {
+        return view('rates::admin.rates.index');
+    }
+}

--- a/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Models/FeeRuleModel.php
+++ b/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Models/FeeRuleModel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FeeRuleModel extends Model
+{
+    protected $table = 'fee_rules';
+
+    protected $fillable = [
+        'service_key','from_amount','to_amount','fee_type','value','is_active',
+    ];
+}

--- a/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Models/RateModel.php
+++ b/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Models/RateModel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RateModel extends Model
+{
+    protected $table = 'rates';
+
+    protected $fillable = [
+        'base_currency','usd_buy','usd_sell',
+    ];
+}

--- a/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Repositories/FeeRuleRepository.php
+++ b/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Repositories/FeeRuleRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Modules\Rates\Domain\Entities\FeeRule;
+use App\Modules\Rates\Domain\Enums\FeeType;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+use App\Modules\Rates\Infrastructure\Persistence\Eloquent\Models\FeeRuleModel;
+use Illuminate\Support\Facades\Cache;
+
+class FeeRuleRepository implements FeeRuleRepositoryInterface
+{
+    public function forService(string $serviceKey): array
+    {
+        $ttl = config('rates.cache_ttl', 0);
+        $key = "fees:{$serviceKey}";
+        if ($ttl > 0 && ($cached = Cache::get($key))) {
+            return $cached;
+        }
+
+        $models = FeeRuleModel::where('service_key', $serviceKey)
+            ->orderBy('from_amount')
+            ->get();
+
+        $rules = $models->map(fn($m) => new FeeRule(
+            $m->service_key,
+            (string) $m->from_amount,
+            (string) $m->to_amount,
+            FeeType::from($m->fee_type),
+            (string) $m->value,
+            (bool) $m->is_active,
+        ))->all();
+
+        if ($ttl > 0) {
+            Cache::put($key, $rules, $ttl);
+        }
+        return $rules;
+    }
+
+    public function upsert(FeeRule $rule): FeeRule
+    {
+        $model = FeeRuleModel::updateOrCreate(
+            [
+                'service_key' => $rule->serviceKey,
+                'from_amount' => $rule->fromAmount,
+                'to_amount' => $rule->toAmount,
+            ],
+            [
+                'fee_type' => $rule->feeType->value,
+                'value' => $rule->value,
+                'is_active' => $rule->isActive,
+            ]
+        );
+
+        Cache::forget("fees:{$rule->serviceKey}");
+
+        return new FeeRule(
+            $model->service_key,
+            (string) $model->from_amount,
+            (string) $model->to_amount,
+            FeeType::from($model->fee_type),
+            (string) $model->value,
+            (bool) $model->is_active,
+        );
+    }
+}

--- a/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Repositories/RateRepository.php
+++ b/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Repositories/RateRepository.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Modules\Rates\Domain\Entities\Rate;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+use App\Modules\Rates\Infrastructure\Persistence\Eloquent\Models\RateModel;
+use Illuminate\Support\Facades\Cache;
+
+class RateRepository implements RateRepositoryInterface
+{
+    public function latest(): ?Rate
+    {
+        $ttl = config('rates.cache_ttl', 0);
+        $key = 'rates:current';
+        if ($ttl > 0 && ($cached = Cache::get($key))) {
+            return $cached;
+        }
+
+        $model = RateModel::latest('id')->first();
+        if (! $model) {
+            return null;
+        }
+
+        $rate = new Rate($model->base_currency, (string) $model->usd_buy, (string) $model->usd_sell, $model->updated_at?->toImmutable());
+        if ($ttl > 0) {
+            Cache::put($key, $rate, $ttl);
+        }
+        return $rate;
+    }
+
+    public function upsert(Rate $rate): Rate
+    {
+        $model = RateModel::create([
+            'base_currency' => $rate->baseCurrency,
+            'usd_buy' => $rate->usdBuy,
+            'usd_sell' => $rate->usdSell,
+        ]);
+
+        Cache::forget('rates:current');
+
+        return new Rate($model->base_currency, (string) $model->usd_buy, (string) $model->usd_sell, $model->updated_at?->toImmutable());
+    }
+}

--- a/src/app/Modules/Rates/Infrastructure/Services/FeeEngine.php
+++ b/src/app/Modules/Rates/Infrastructure/Services/FeeEngine.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Services;
+
+use App\Modules\Rates\Domain\Enums\FeeType;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+use App\Modules\Rates\Domain\Services\FeeEngineInterface;
+
+class FeeEngine implements FeeEngineInterface
+{
+    public function __construct(private FeeRuleRepositoryInterface $rules) {}
+
+    public function compute(string $serviceKey, string $amountUsd): string
+    {
+        foreach ($this->rules->forService($serviceKey) as $rule) {
+            if ($rule->matches($amountUsd)) {
+                return match ($rule->feeType) {
+                    FeeType::Fixed => $rule->value,
+                    FeeType::Percent => bcdiv(bcmul($amountUsd, $rule->value, 4), '100', 4),
+                };
+            }
+        }
+        return '0';
+    }
+}

--- a/src/app/Modules/Rates/RatesServiceProvider.php
+++ b/src/app/Modules/Rates/RatesServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Modules\Rates;
+
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+use App\Modules\Rates\Domain\Services\FeeEngineInterface;
+use App\Modules\Rates\Infrastructure\Persistence\Eloquent\Repositories\FeeRuleRepository;
+use App\Modules\Rates\Infrastructure\Persistence\Eloquent\Repositories\RateRepository;
+use App\Modules\Rates\Infrastructure\Services\FeeEngine;
+use Illuminate\Support\ServiceProvider;
+
+class RatesServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(RateRepositoryInterface::class, RateRepository::class);
+        $this->app->bind(FeeRuleRepositoryInterface::class, FeeRuleRepository::class);
+        $this->app->bind(FeeEngineInterface::class, FeeEngine::class);
+    }
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/routes/web.php');
+        $this->loadViewsFrom(__DIR__.'/Application/Views', 'rates');
+    }
+}

--- a/src/app/Modules/Rates/routes/web.php
+++ b/src/app/Modules/Rates/routes/web.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Modules\Rates\Http\Controllers\Admin\RateController;
+use App\Modules\Rates\Http\Controllers\Admin\FeeRuleController;
+
+Route::middleware(['web','auth'])
+    ->prefix('admin/rates')
+    ->group(function(){
+        Route::get('/', [RateController::class, 'index'])->name('admin.rates.index');
+        Route::get('/fees', [FeeRuleController::class, 'index'])->name('admin.fees.index');
+        Route::get('/quote-tester', fn() => view('rates::admin.quote.tester'))->name('admin.quote.tester');
+    });

--- a/src/app/Modules/SharedKernel/Application/Livewire/Dialog.php
+++ b/src/app/Modules/SharedKernel/Application/Livewire/Dialog.php
@@ -1,5 +1,6 @@
 <?php
-namespace App\Modules\SharedKernel\Application\View\Components;
+
+namespace App\Modules\SharedKernel\Application\Livewire;
 
 use Illuminate\View\Component;
 

--- a/src/config/modules.php
+++ b/src/config/modules.php
@@ -3,6 +3,8 @@ return [
     // امکان روشن/خاموش کردن ماژول‌ها در آینده
     'enabled' => [
         'SharedKernel' => true,
+        'Rates' => true,
+        'Orders' => true,
         // 'Auth' => true, 'Catalog' => true, ...
     ],
 ];

--- a/src/config/orders.php
+++ b/src/config/orders.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'status_enum' => [
+        'pending','paid','processing','done','refunded','failed'
+    ],
+];

--- a/src/config/rates.php
+++ b/src/config/rates.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'cache_ttl' => 300,
+    'default_rate_field' => 'usd_sell',
+    'service_overrides' => [
+        // 'giftcard' => 'usd_buy',
+    ],
+];

--- a/src/database/migrations/2025_08_11_130000_create_rates_table.php
+++ b/src/database/migrations/2025_08_11_130000_create_rates_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('rates', function (Blueprint $t) {
+            $t->id();
+            $t->string('base_currency')->default('IRR');
+            $t->decimal('usd_buy', 18, 4);
+            $t->decimal('usd_sell', 18, 4);
+            $t->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rates');
+    }
+};

--- a/src/database/migrations/2025_08_11_130100_create_fee_rules_table.php
+++ b/src/database/migrations/2025_08_11_130100_create_fee_rules_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('fee_rules', function (Blueprint $t) {
+            $t->id();
+            $t->string('service_key');
+            $t->decimal('from_amount', 18, 2);
+            $t->decimal('to_amount', 18, 2);
+            $t->enum('fee_type', ['fixed','percent']);
+            $t->decimal('value', 18, 4);
+            $t->boolean('is_active')->default(true);
+            $t->timestamps();
+            $t->index(['service_key','from_amount','to_amount']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fee_rules');
+    }
+};

--- a/src/database/migrations/2025_08_11_130200_create_orders_table.php
+++ b/src/database/migrations/2025_08_11_130200_create_orders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $t) {
+            $t->id();
+            $t->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $t->string('service_key');
+            $t->string('currency')->default('USD');
+            $t->decimal('amount_usd', 18, 2);
+            $t->decimal('fee_usd', 18, 4);
+            $t->decimal('subtotal_usd', 18, 4);
+            $t->decimal('rate_used', 18, 4);
+            $t->decimal('total_irr', 20, 2);
+            $t->json('meta')->nullable();
+            $t->json('quote_breakdown');
+            $t->string('status');
+            $t->timestamps();
+            $t->index(['service_key','status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/src/database/migrations/2025_08_11_130300_create_order_items_table.php
+++ b/src/database/migrations/2025_08_11_130300_create_order_items_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('order_items', function (Blueprint $t) {
+            $t->id();
+            $t->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
+            $t->string('sku')->nullable();
+            $t->string('title');
+            $t->decimal('unit_price_usd', 18, 4);
+            $t->integer('qty')->default(1);
+            $t->decimal('line_total_usd', 18, 4);
+            $t->json('meta')->nullable();
+            $t->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('order_items');
+    }
+};

--- a/src/storage/.gitignore
+++ b/src/storage/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/storage/framework/.gitignore
+++ b/src/storage/framework/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/tests/Unit/CalculateQuoteTest.php
+++ b/src/tests/Unit/CalculateQuoteTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Rates\Application\DTOs\QuoteInput;
+use App\Modules\Rates\Application\UseCases\CalculateQuote;
+use App\Modules\Rates\Domain\Entities\Rate;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+use App\Modules\Rates\Domain\Services\FeeEngineInterface;
+use Tests\TestCase;
+
+class CalculateQuoteTest extends TestCase
+{
+    public function test_calculates_quote(): void
+    {
+        $rateRepo = new class implements RateRepositoryInterface {
+            public function latest(): ?Rate { return new Rate('IRR','50000','60000'); }
+            public function upsert(Rate $rate): Rate { return $rate; }
+        };
+        $feeEngine = new class implements FeeEngineInterface {
+            public function compute(string $serviceKey, string $amountUsd): string { return '5'; }
+        };
+        $useCase = new CalculateQuote($rateRepo, $feeEngine);
+        $result = $useCase(new QuoteInput('payforme','100'));
+        $this->assertSame('100', $result->amountUsd);
+        $this->assertSame('5', $result->feeUsd);
+        $this->assertSame('105.0000', $result->subtotalUsd);
+        $this->assertSame('60000', $result->rateUsed);
+        $this->assertSame((string) round(105*60000), $result->totalIrr);
+    }
+}

--- a/src/tests/Unit/CreateOrderTest.php
+++ b/src/tests/Unit/CreateOrderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Orders\Application\DTOs\CreateOrderInput;
+use App\Modules\Orders\Application\UseCases\CreateOrder;
+use App\Modules\Orders\Domain\Entities\Order;
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+use App\Modules\Rates\Application\UseCases\CalculateQuote;
+use Tests\TestCase;
+
+class CreateOrderTest extends TestCase
+{
+    public function test_creates_order_with_quote_snapshot(): void
+    {
+        $orderRepo = new class implements OrderRepositoryInterface {
+            public ?Order $created = null;
+            public function create(Order $order): Order { $order->id = 1; $this->created = $order; return $order; }
+            public function find(int $id): ?Order { return null; }
+        };
+        $quoteUseCase = new CalculateQuote(
+            new class implements \App\Modules\Rates\Domain\Repositories\RateRepositoryInterface {
+                public function latest(): ?\App\Modules\Rates\Domain\Entities\Rate { return new \App\Modules\Rates\Domain\Entities\Rate('IRR','50000','60000'); }
+                public function upsert(\App\Modules\Rates\Domain\Entities\Rate $rate): \App\Modules\Rates\Domain\Entities\Rate { return $rate; }
+            },
+            new class implements \App\Modules\Rates\Domain\Services\FeeEngineInterface {
+                public function compute(string $serviceKey, string $amountUsd): string { return '5'; }
+            }
+        );
+        $useCase = new CreateOrder($orderRepo, $quoteUseCase);
+        $input = new CreateOrderInput(1,'payforme','100');
+        $view = $useCase($input);
+        $this->assertSame(1, $view->id);
+        $this->assertSame('payforme', $view->serviceKey);
+        $this->assertSame(OrderStatus::Pending, $view->status);
+        $this->assertSame((string) round(105*60000), $view->totalIrr);
+        $this->assertEquals('105.0000', $orderRepo->created->subtotalUsd);
+    }
+}

--- a/src/tests/Unit/FeeEngineTest.php
+++ b/src/tests/Unit/FeeEngineTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Rates\Domain\Entities\FeeRule;
+use App\Modules\Rates\Domain\Enums\FeeType;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+use App\Modules\Rates\Infrastructure\Services\FeeEngine;
+use PHPUnit\Framework\TestCase;
+
+class FeeEngineTest extends TestCase
+{
+    public function test_percent_fee_rule(): void
+    {
+        $repo = new class implements FeeRuleRepositoryInterface {
+            public function forService(string $serviceKey): array { return [ new FeeRule($serviceKey,'0','200',FeeType::Percent,'5') ]; }
+            public function upsert(FeeRule $rule): FeeRule { return $rule; }
+        };
+        $engine = new FeeEngine($repo);
+        $this->assertSame('5.0000', $engine->compute('svc', '100'));
+    }
+
+    public function test_fixed_fee_rule(): void
+    {
+        $repo = new class implements FeeRuleRepositoryInterface {
+            public function forService(string $serviceKey): array { return [ new FeeRule($serviceKey,'0','200',FeeType::Fixed,'3') ]; }
+            public function upsert(FeeRule $rule): FeeRule { return $rule; }
+        };
+        $engine = new FeeEngine($repo);
+        $this->assertSame('3', $engine->compute('svc', '100'));
+    }
+
+    public function test_no_matching_rule(): void
+    {
+        $repo = new class implements FeeRuleRepositoryInterface {
+            public function forService(string $serviceKey): array { return []; }
+            public function upsert(FeeRule $rule): FeeRule { return $rule; }
+        };
+        $engine = new FeeEngine($repo);
+        $this->assertSame('0', $engine->compute('svc', '100'));
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Rates module with fee engine, rate storage, and quote calculation
- introduce Orders module to persist quote breakdown snapshots
- add database migrations and configuration for rates, fees, and orders

## Testing
- `php artisan test --testsuite=Unit`
- `php artisan test --testsuite=Feature` *(fails: Expected response status code [200] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_689a21030a588326bc5c472011e22744