### PR TITLE
feat: add rates, fees and orders core

### DIFF
--- a/src/app/Modules/Orders/Application/DTOs/CreateOrderInput.php
+++ b/src/app/Modules/Orders/Application/DTOs/CreateOrderInput.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Orders\Application\DTOs;
+
+class CreateOrderInput
+{
+    public function __construct(
+        public int $userId,
+        public string $serviceKey,
+        public string $amountUsd,
+        public ?array $meta = null,
+    ) {}
+}

--- a/src/app/Modules/Orders/Application/DTOs/OrderView.php
+++ b/src/app/Modules/Orders/Application/DTOs/OrderView.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Modules\Orders\Application\DTOs;
+
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+
+class OrderView
+{
+    public function __construct(
+        public int $id,
+        public string $serviceKey,
+        public string $amountUsd,
+        public string $totalIrr,
+        public OrderStatus $status,
+    ) {}
+}

--- a/src/app/Modules/Orders/Application/UseCases/CreateOrder.php
+++ b/src/app/Modules/Orders/Application/UseCases/CreateOrder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Modules\Orders\Application\UseCases;
+
+use App\Modules\Orders\Application\DTOs\CreateOrderInput;
+use App\Modules\Orders\Domain\Entities\Order;
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+use App\Modules\Rates\Application\UseCases\CalculateQuote;
+use App\Modules\Rates\Application\DTOs\QuoteInput;
+
+class CreateOrder
+{
+    public function __construct(
+        private CalculateQuote $quote,
+        private OrderRepositoryInterface $repo,
+    ) {}
+
+    public function __invoke(CreateOrderInput $input): Order
+    {
+        $result = ($this->quote)(new QuoteInput($input->serviceKey, $input->amountUsd));
+
+        $order = new Order(
+            $input->userId,
+            $input->serviceKey,
+            $result->amountUsd,
+            $result->feeUsd,
+            $result->subtotalUsd,
+            $result->rateUsed,
+            $result->totalIrr,
+            OrderStatus::Pending,
+            [
+                'amount_usd' => $result->amountUsd,
+                'fee_usd' => $result->feeUsd,
+                'subtotal_usd' => $result->subtotalUsd,
+                'rate_used' => $result->rateUsed,
+                'total_irr' => $result->totalIrr,
+            ],
+            $input->meta,
+        );
+
+        return $this->repo->create($order);
+    }
+}

--- a/src/app/Modules/Orders/Application/UseCases/GetOrder.php
+++ b/src/app/Modules/Orders/Application/UseCases/GetOrder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Modules\Orders\Application\UseCases;
+
+use App\Modules\Orders\Application\DTOs\OrderView;
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+
+class GetOrder
+{
+    public function __construct(private OrderRepositoryInterface $repo)
+    {
+    }
+
+    public function __invoke(int $id): ?OrderView
+    {
+        $order = $this->repo->find($id);
+        if (! $order) {
+            return null;
+        }
+
+        return new OrderView(
+            $order->id ?? 0,
+            $order->serviceKey,
+            $order->amountUsd,
+            $order->totalIrr,
+            $order->status,
+        );
+    }
+}

--- a/src/app/Modules/Orders/Application/Views/admin/orders/index.blade.php
+++ b/src/app/Modules/Orders/Application/Views/admin/orders/index.blade.php
@@ -1,0 +1,3 @@
+<div class="p-4">
+    <h1 class="text-xl">سفارش‌ها</h1>
+</div>

--- a/src/app/Modules/Orders/Application/Views/admin/orders/show.blade.php
+++ b/src/app/Modules/Orders/Application/Views/admin/orders/show.blade.php
@@ -1,0 +1,3 @@
+<div class="p-4">
+    <h1 class="text-xl">جزئیات سفارش</h1>
+</div>

--- a/src/app/Modules/Orders/Domain/Entities/Order.php
+++ b/src/app/Modules/Orders/Domain/Entities/Order.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Modules\Orders\Domain\Entities;
+
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+
+class Order
+{
+    public function __construct(
+        public int $userId,
+        public string $serviceKey,
+        public string $amountUsd,
+        public string $feeUsd,
+        public string $subtotalUsd,
+        public string $rateUsed,
+        public string $totalIrr,
+        public OrderStatus $status,
+        public array $quoteBreakdown,
+        public ?array $meta = null,
+        public ?int $id = null,
+    ) {}
+}

--- a/src/app/Modules/Orders/Domain/Entities/OrderItem.php
+++ b/src/app/Modules/Orders/Domain/Entities/OrderItem.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Modules\Orders\Domain\Entities;
+
+class OrderItem
+{
+    public function __construct(
+        public int $orderId,
+        public ?string $sku,
+        public string $title,
+        public string $unitPriceUsd,
+        public int $qty,
+        public string $lineTotalUsd,
+        public ?array $meta = null,
+        public ?int $id = null,
+    ) {}
+}

--- a/src/app/Modules/Orders/Domain/Enums/OrderStatus.php
+++ b/src/app/Modules/Orders/Domain/Enums/OrderStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Orders\Domain\Enums;
+
+enum OrderStatus: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Processing = 'processing';
+    case Done = 'done';
+    case Refunded = 'refunded';
+    case Failed = 'failed';
+}

--- a/src/app/Modules/Orders/Domain/Repositories/OrderRepositoryInterface.php
+++ b/src/app/Modules/Orders/Domain/Repositories/OrderRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Modules\Orders\Domain\Repositories;
+
+use App\Modules\Orders\Domain\Entities\Order;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+interface OrderRepositoryInterface
+{
+    public function create(Order $order): Order;
+
+    public function find(int $id): ?Order;
+
+    public function paginate(array $filters = []): LengthAwarePaginator;
+}

--- a/src/app/Modules/Orders/Http/Controllers/Admin/OrderController.php
+++ b/src/app/Modules/Orders/Http/Controllers/Admin/OrderController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Orders\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+class OrderController extends Controller
+{
+    public function index()
+    {
+        return view('orders::admin.orders.index');
+    }
+
+    public function show(int $order)
+    {
+        return view('orders::admin.orders.show');
+    }
+}

--- a/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Models/OrderItemModel.php
+++ b/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Models/OrderItemModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Modules\Orders\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OrderItemModel extends Model
+{
+    protected $table = 'order_items';
+
+    protected $fillable = [
+        'order_id','sku','title','unit_price_usd','qty','line_total_usd','meta'
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
+
+    public function order()
+    {
+        return $this->belongsTo(OrderModel::class, 'order_id');
+    }
+}

--- a/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Models/OrderModel.php
+++ b/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Models/OrderModel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\Orders\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OrderModel extends Model
+{
+    protected $table = 'orders';
+
+    protected $fillable = [
+        'user_id','service_key','currency','amount_usd','fee_usd','subtotal_usd','rate_used','total_irr','meta','quote_breakdown','status'
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+        'quote_breakdown' => 'array',
+    ];
+
+    public function items()
+    {
+        return $this->hasMany(OrderItemModel::class, 'order_id');
+    }
+}

--- a/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Repositories/OrderRepository.php
+++ b/src/app/Modules/Orders/Infrastructure/Persistence/Eloquent/Repositories/OrderRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Modules\Orders\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Modules\Orders\Domain\Entities\Order;
+use App\Modules\Orders\Domain\Enums\OrderStatus;
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+use App\Modules\Orders\Infrastructure\Persistence\Eloquent\Models\OrderModel;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+class OrderRepository implements OrderRepositoryInterface
+{
+    public function create(Order $order): Order
+    {
+        $model = OrderModel::query()->create([
+            'user_id' => $order->userId,
+            'service_key' => $order->serviceKey,
+            'currency' => 'USD',
+            'amount_usd' => $order->amountUsd,
+            'fee_usd' => $order->feeUsd,
+            'subtotal_usd' => $order->subtotalUsd,
+            'rate_used' => $order->rateUsed,
+            'total_irr' => $order->totalIrr,
+            'meta' => $order->meta,
+            'quote_breakdown' => $order->quoteBreakdown,
+            'status' => $order->status->value,
+        ]);
+
+        return $this->map($model);
+    }
+
+    public function find(int $id): ?Order
+    {
+        $model = OrderModel::query()->find($id);
+        return $model ? $this->map($model) : null;
+    }
+
+    public function paginate(array $filters = []): LengthAwarePaginator
+    {
+        $query = OrderModel::query();
+        if (isset($filters['service_key'])) {
+            $query->where('service_key', $filters['service_key']);
+        }
+        if (isset($filters['status'])) {
+            $query->where('status', $filters['status']);
+        }
+        return $query->paginate();
+    }
+
+    protected function map(OrderModel $m): Order
+    {
+        return new Order(
+            $m->user_id,
+            $m->service_key,
+            $m->amount_usd,
+            $m->fee_usd,
+            $m->subtotal_usd,
+            $m->rate_used,
+            $m->total_irr,
+            OrderStatus::from($m->status),
+            $m->quote_breakdown ?? [],
+            $m->meta ?? [],
+            $m->id,
+        );
+    }
+}

--- a/src/app/Modules/Orders/OrdersServiceProvider.php
+++ b/src/app/Modules/Orders/OrdersServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Modules\Orders;
+
+use Illuminate\Support\ServiceProvider;
+use App\Modules\Orders\Domain\Repositories\OrderRepositoryInterface;
+use App\Modules\Orders\Infrastructure\Persistence\Eloquent\Repositories\OrderRepository;
+
+class OrdersServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(OrderRepositoryInterface::class, OrderRepository::class);
+    }
+
+    public function boot(): void
+    {
+    }
+}

--- a/src/app/Modules/Orders/routes/web.php
+++ b/src/app/Modules/Orders/routes/web.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Modules\Orders\Http\Controllers\Admin\OrderController;
+
+Route::middleware(['web','auth'])
+    ->prefix('admin/orders')
+    ->group(function(){
+        Route::get('/', [OrderController::class, 'index'])->name('admin.orders.index');
+        Route::get('/{order}', [OrderController::class, 'show'])->name('admin.orders.show');
+    });

--- a/src/app/Modules/Rates/Application/DTOs/QuoteInput.php
+++ b/src/app/Modules/Rates/Application/DTOs/QuoteInput.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Rates\Application\DTOs;
+
+class QuoteInput
+{
+    public function __construct(
+        public string $serviceKey,
+        public string $amountUsd,
+    ) {}
+}

--- a/src/app/Modules/Rates/Application/DTOs/QuoteResult.php
+++ b/src/app/Modules/Rates/Application/DTOs/QuoteResult.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Rates\Application\DTOs;
+
+class QuoteResult
+{
+    public function __construct(
+        public string $amountUsd,
+        public string $feeUsd,
+        public string $subtotalUsd,
+        public string $rateUsed,
+        public string $totalIrr,
+    ) {}
+}

--- a/src/app/Modules/Rates/Application/Livewire/Admin/QuoteTester.php
+++ b/src/app/Modules/Rates/Application/Livewire/Admin/QuoteTester.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Modules\Rates\Application\Livewire\Admin;
+
+use Livewire\Component;
+use App\Modules\Rates\Application\UseCases\CalculateQuote;
+use App\Modules\Rates\Application\DTOs\QuoteInput;
+
+class QuoteTester extends Component
+{
+    public string $serviceKey = 'payforme';
+    public string $amountUsd = '0';
+    public ?array $result = null;
+
+    public function submit(CalculateQuote $calc): void
+    {
+        $this->validate([
+            'serviceKey' => 'required|string',
+            'amountUsd' => 'required|numeric|gt:0',
+        ]);
+
+        $dto = new QuoteInput($this->serviceKey, $this->amountUsd);
+        $res = $calc($dto);
+        $this->result = [
+            'amount_usd' => $res->amountUsd,
+            'fee_usd' => $res->feeUsd,
+            'subtotal_usd' => $res->subtotalUsd,
+            'rate_used' => $res->rateUsed,
+            'total_irr' => $res->totalIrr,
+        ];
+    }
+
+    public function render()
+    {
+        return view('rates::admin.quote.tester');
+    }
+}

--- a/src/app/Modules/Rates/Application/UseCases/CalculateQuote.php
+++ b/src/app/Modules/Rates/Application/UseCases/CalculateQuote.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Modules\Rates\Application\UseCases;
+
+use App\Modules\Rates\Application\DTOs\QuoteInput;
+use App\Modules\Rates\Application\DTOs\QuoteResult;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+use App\Modules\Rates\Domain\Services\FeeEngineInterface;
+
+class CalculateQuote
+{
+    public function __construct(
+        private RateRepositoryInterface $rates,
+        private FeeEngineInterface $fees,
+    ) {}
+
+    public function __invoke(QuoteInput $input): QuoteResult
+    {
+        $rate = $this->rates->latest();
+        if (! $rate) {
+            throw new \RuntimeException('No rates available');
+        }
+
+        $field = config("rates.service_overrides.{$input->serviceKey}")
+            ?? config('rates.default_rate_field');
+
+        $rateUsed = $field === 'usd_buy' ? $rate->usdBuy : $rate->usdSell;
+
+        $feeUsd = $this->fees->compute($input->serviceKey, $input->amountUsd);
+        $subtotalUsd = bcadd($input->amountUsd, $feeUsd, 4);
+        $totalIrr = (string) round((float) bcmul($subtotalUsd, $rateUsed, 4));
+
+        return new QuoteResult(
+            $input->amountUsd,
+            $feeUsd,
+            $subtotalUsd,
+            $rateUsed,
+            $totalIrr,
+        );
+    }
+}

--- a/src/app/Modules/Rates/Application/UseCases/UpsertFeeRule.php
+++ b/src/app/Modules/Rates/Application/UseCases/UpsertFeeRule.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\Rates\Application\UseCases;
+
+use App\Modules\Rates\Domain\Entities\FeeRule;
+use App\Modules\Rates\Domain\Enums\FeeType;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+
+class UpsertFeeRule
+{
+    public function __construct(private FeeRuleRepositoryInterface $repo)
+    {
+    }
+
+    public function __invoke(
+        string $serviceKey,
+        string $fromAmount,
+        string $toAmount,
+        string $feeType,
+        string $value,
+        bool $isActive = true,
+    ): FeeRule {
+        $rule = new FeeRule(
+            $serviceKey,
+            $fromAmount,
+            $toAmount,
+            FeeType::from($feeType),
+            $value,
+            $isActive,
+        );
+
+        return $this->repo->upsert($rule);
+    }
+}

--- a/src/app/Modules/Rates/Application/UseCases/UpsertRate.php
+++ b/src/app/Modules/Rates/Application/UseCases/UpsertRate.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Modules\Rates\Application\UseCases;
+
+use App\Modules\Rates\Domain\Entities\Rate;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+
+class UpsertRate
+{
+    public function __construct(private RateRepositoryInterface $repo)
+    {
+    }
+
+    public function __invoke(string $usdBuy, string $usdSell): Rate
+    {
+        $rate = new Rate('IRR', $usdBuy, $usdSell);
+        return $this->repo->upsert($rate);
+    }
+}

--- a/src/app/Modules/Rates/Application/Views/admin/fees/index.blade.php
+++ b/src/app/Modules/Rates/Application/Views/admin/fees/index.blade.php
@@ -1,0 +1,3 @@
+<div class="p-4">
+    <h1 class="text-xl">قوانین کارمزد</h1>
+</div>

--- a/src/app/Modules/Rates/Application/Views/admin/quote/tester.blade.php
+++ b/src/app/Modules/Rates/Application/Views/admin/quote/tester.blade.php
@@ -1,0 +1,17 @@
+<div class="p-4" wire:poll="noop">
+    <h1 class="text-xl mb-4">تست محاسبه</h1>
+    <form wire:submit.prevent="submit" class="space-y-2">
+        <div>
+            <label>Service</label>
+            <input type="text" wire:model="serviceKey" class="border" />
+        </div>
+        <div>
+            <label>Amount USD</label>
+            <input type="number" step="0.01" wire:model="amountUsd" class="border" />
+        </div>
+        <button type="submit" class="bg-blue-500 text-white px-3 py-1">محاسبه</button>
+    </form>
+    @if($result)
+        <pre class="mt-4">{{ json_encode($result, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE) }}</pre>
+    @endif
+</div>

--- a/src/app/Modules/Rates/Application/Views/admin/rates/index.blade.php
+++ b/src/app/Modules/Rates/Application/Views/admin/rates/index.blade.php
@@ -1,0 +1,3 @@
+<div class="p-4">
+    <h1 class="text-xl">نرخ‌ها</h1>
+</div>

--- a/src/app/Modules/Rates/Domain/Entities/FeeRule.php
+++ b/src/app/Modules/Rates/Domain/Entities/FeeRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Entities;
+
+use App\Modules\Rates\Domain\Enums\FeeType;
+
+class FeeRule
+{
+    public function __construct(
+        public string $serviceKey,
+        public string $fromAmount,
+        public string $toAmount,
+        public FeeType $feeType,
+        public string $value,
+        public bool $isActive = true,
+    ) {}
+
+    public function matches(string $amount): bool
+    {
+        return bccomp($amount, $this->fromAmount, 2) >= 0
+            && bccomp($amount, $this->toAmount, 2) <= 0
+            && $this->isActive;
+    }
+}

--- a/src/app/Modules/Rates/Domain/Entities/Rate.php
+++ b/src/app/Modules/Rates/Domain/Entities/Rate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Entities;
+
+class Rate
+{
+    public function __construct(
+        public string $baseCurrency,
+        public string $usdBuy,
+        public string $usdSell,
+        public ?\DateTimeInterface $updatedAt = null,
+    ) {}
+}

--- a/src/app/Modules/Rates/Domain/Enums/FeeType.php
+++ b/src/app/Modules/Rates/Domain/Enums/FeeType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Enums;
+
+enum FeeType: string
+{
+    case Fixed = 'fixed';
+    case Percent = 'percent';
+}

--- a/src/app/Modules/Rates/Domain/Repositories/FeeRuleRepositoryInterface.php
+++ b/src/app/Modules/Rates/Domain/Repositories/FeeRuleRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Repositories;
+
+use App\Modules\Rates\Domain\Entities\FeeRule;
+
+interface FeeRuleRepositoryInterface
+{
+    /** @return FeeRule[] */
+    public function forService(string $serviceKey): array;
+
+    public function upsert(FeeRule $rule): FeeRule;
+}

--- a/src/app/Modules/Rates/Domain/Repositories/RateRepositoryInterface.php
+++ b/src/app/Modules/Rates/Domain/Repositories/RateRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Repositories;
+
+use App\Modules\Rates\Domain\Entities\Rate;
+
+interface RateRepositoryInterface
+{
+    public function latest(): ?Rate;
+
+    public function upsert(Rate $rate): Rate;
+}

--- a/src/app/Modules/Rates/Domain/Services/FeeEngineInterface.php
+++ b/src/app/Modules/Rates/Domain/Services/FeeEngineInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Modules\Rates\Domain\Services;
+
+interface FeeEngineInterface
+{
+    public function compute(string $serviceKey, string $amountUsd): string;
+}

--- a/src/app/Modules/Rates/Domain/ValueObjects/Fee.php
+++ b/src/app/Modules/Rates/Domain/ValueObjects/Fee.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Rates\Domain\ValueObjects;
+
+use App\Modules\Rates\Domain\Enums\FeeType;
+
+class Fee
+{
+    public function __construct(
+        public FeeType $type,
+        public string $value,
+    ) {}
+}

--- a/src/app/Modules/Rates/Events/FeeRulesChanged.php
+++ b/src/app/Modules/Rates/Events/FeeRulesChanged.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Modules\Rates\Events;
+
+class FeeRulesChanged
+{
+    public function __construct(public string $serviceKey)
+    {
+    }
+}

--- a/src/app/Modules/Rates/Events/RatesUpdated.php
+++ b/src/app/Modules/Rates/Events/RatesUpdated.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Modules\Rates\Events;
+
+class RatesUpdated
+{
+}

--- a/src/app/Modules/Rates/Http/Controllers/Admin/FeeRuleController.php
+++ b/src/app/Modules/Rates/Http/Controllers/Admin/FeeRuleController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Rates\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+class FeeRuleController extends Controller
+{
+    public function index()
+    {
+        return view('rates::admin.fees.index');
+    }
+}

--- a/src/app/Modules/Rates/Http/Controllers/Admin/RateController.php
+++ b/src/app/Modules/Rates/Http/Controllers/Admin/RateController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\Rates\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+class RateController extends Controller
+{
+    public function index()
+    {
+        return view('rates::admin.rates.index');
+    }
+}

--- a/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Models/FeeRuleModel.php
+++ b/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Models/FeeRuleModel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FeeRuleModel extends Model
+{
+    protected $table = 'fee_rules';
+
+    protected $fillable = [
+        'service_key','from_amount','to_amount','fee_type','value','is_active'
+    ];
+}

--- a/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Models/RateModel.php
+++ b/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Models/RateModel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RateModel extends Model
+{
+    protected $table = 'rates';
+
+    protected $fillable = ['base_currency','usd_buy','usd_sell'];
+}

--- a/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Repositories/FeeRuleRepository.php
+++ b/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Repositories/FeeRuleRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Modules\Rates\Domain\Entities\FeeRule;
+use App\Modules\Rates\Domain\Enums\FeeType;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+use App\Modules\Rates\Infrastructure\Persistence\Eloquent\Models\FeeRuleModel;
+use App\Modules\Rates\Events\FeeRulesChanged;
+use Illuminate\Support\Facades\Cache;
+
+class FeeRuleRepository implements FeeRuleRepositoryInterface
+{
+    public function forService(string $serviceKey): array
+    {
+        $key = "fees:$serviceKey";
+        $ttl = config('rates.cache_ttl');
+
+        $callback = function () use ($serviceKey) {
+            return FeeRuleModel::query()
+                ->where('service_key', $serviceKey)
+                ->orderBy('from_amount')
+                ->get()
+                ->map(fn($m) => $this->map($m))
+                ->all();
+        };
+
+        if ($ttl > 0) {
+            return Cache::remember($key, $ttl, $callback);
+        }
+
+        return $callback();
+    }
+
+    public function upsert(FeeRule $rule): FeeRule
+    {
+        $model = FeeRuleModel::query()->create([
+            'service_key' => $rule->serviceKey,
+            'from_amount' => $rule->fromAmount,
+            'to_amount' => $rule->toAmount,
+            'fee_type' => $rule->feeType->value,
+            'value' => $rule->value,
+            'is_active' => $rule->isActive,
+        ]);
+
+        Cache::forget("fees:{$rule->serviceKey}");
+        event(new FeeRulesChanged($rule->serviceKey));
+
+        return $this->map($model);
+    }
+
+    protected function map(FeeRuleModel $m): FeeRule
+    {
+        return new FeeRule(
+            $m->service_key,
+            $m->from_amount,
+            $m->to_amount,
+            FeeType::from($m->fee_type),
+            $m->value,
+            (bool)$m->is_active,
+        );
+    }
+}

--- a/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Repositories/RateRepository.php
+++ b/src/app/Modules/Rates/Infrastructure/Persistence/Eloquent/Repositories/RateRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Modules\Rates\Domain\Entities\Rate;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+use App\Modules\Rates\Infrastructure\Persistence\Eloquent\Models\RateModel;
+use App\Modules\Rates\Events\RatesUpdated;
+use Illuminate\Support\Facades\Cache;
+
+class RateRepository implements RateRepositoryInterface
+{
+    public function latest(): ?Rate
+    {
+        $ttl = config('rates.cache_ttl');
+        $key = 'rates:current';
+
+        if ($ttl > 0) {
+            return Cache::remember($key, $ttl, function () {
+                $model = RateModel::query()->latest()->first();
+                return $model ? $this->map($model) : null;
+            });
+        }
+
+        $model = RateModel::query()->latest()->first();
+        return $model ? $this->map($model) : null;
+    }
+
+    public function upsert(Rate $rate): Rate
+    {
+        $model = RateModel::query()->create([
+            'base_currency' => $rate->baseCurrency,
+            'usd_buy' => $rate->usdBuy,
+            'usd_sell' => $rate->usdSell,
+        ]);
+
+        Cache::forget('rates:current');
+        event(new RatesUpdated());
+
+        return $this->map($model);
+    }
+
+    protected function map(RateModel $model): Rate
+    {
+        return new Rate(
+            $model->base_currency,
+            $model->usd_buy,
+            $model->usd_sell,
+            $model->updated_at,
+        );
+    }
+}

--- a/src/app/Modules/Rates/Infrastructure/Services/FeeEngine.php
+++ b/src/app/Modules/Rates/Infrastructure/Services/FeeEngine.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Modules\Rates\Infrastructure\Services;
+
+use App\Modules\Rates\Domain\Enums\FeeType;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+use App\Modules\Rates\Domain\Services\FeeEngineInterface;
+
+class FeeEngine implements FeeEngineInterface
+{
+    public function __construct(private FeeRuleRepositoryInterface $rules)
+    {
+    }
+
+    public function compute(string $serviceKey, string $amountUsd): string
+    {
+        foreach ($this->rules->forService($serviceKey) as $rule) {
+            if ($rule->matches($amountUsd)) {
+                if ($rule->feeType === FeeType::Fixed) {
+                    return $rule->value;
+                }
+
+                return bcdiv(bcmul($amountUsd, $rule->value, 4), '100', 4);
+            }
+        }
+
+        return '0';
+    }
+}

--- a/src/app/Modules/Rates/Listeners/ClearFeeRulesCache.php
+++ b/src/app/Modules/Rates/Listeners/ClearFeeRulesCache.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Rates\Listeners;
+
+use App\Modules\Rates\Events\FeeRulesChanged;
+use Illuminate\Support\Facades\Cache;
+
+class ClearFeeRulesCache
+{
+    public function handle(FeeRulesChanged $event): void
+    {
+        Cache::forget("fees:{$event->serviceKey}");
+    }
+}

--- a/src/app/Modules/Rates/Listeners/ClearRatesCache.php
+++ b/src/app/Modules/Rates/Listeners/ClearRatesCache.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\Rates\Listeners;
+
+use App\Modules\Rates\Events\RatesUpdated;
+use Illuminate\Support\Facades\Cache;
+
+class ClearRatesCache
+{
+    public function handle(RatesUpdated $event): void
+    {
+        Cache::forget('rates:current');
+    }
+}

--- a/src/app/Modules/Rates/RatesServiceProvider.php
+++ b/src/app/Modules/Rates/RatesServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Rates;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Event;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+use App\Modules\Rates\Domain\Services\FeeEngineInterface;
+use App\Modules\Rates\Infrastructure\Persistence\Eloquent\Repositories\RateRepository;
+use App\Modules\Rates\Infrastructure\Persistence\Eloquent\Repositories\FeeRuleRepository;
+use App\Modules\Rates\Infrastructure\Services\FeeEngine;
+use App\Modules\Rates\Events\RatesUpdated;
+use App\Modules\Rates\Events\FeeRulesChanged;
+use App\Modules\Rates\Listeners\ClearRatesCache;
+use App\Modules\Rates\Listeners\ClearFeeRulesCache;
+
+class RatesServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(RateRepositoryInterface::class, RateRepository::class);
+        $this->app->bind(FeeRuleRepositoryInterface::class, FeeRuleRepository::class);
+        $this->app->bind(FeeEngineInterface::class, FeeEngine::class);
+    }
+
+    public function boot(): void
+    {
+        Event::listen(RatesUpdated::class, [ClearRatesCache::class, 'handle']);
+        Event::listen(FeeRulesChanged::class, [ClearFeeRulesCache::class, 'handle']);
+    }
+}

--- a/src/app/Modules/Rates/routes/web.php
+++ b/src/app/Modules/Rates/routes/web.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Modules\Rates\Http\Controllers\Admin\RateController;
+use App\Modules\Rates\Http\Controllers\Admin\FeeRuleController;
+
+Route::middleware(['web','auth'])
+    ->prefix('admin/rates')
+    ->group(function(){
+        Route::get('/', [RateController::class, 'index'])->name('admin.rates.index');
+        Route::get('/fees', [FeeRuleController::class, 'index'])->name('admin.fees.index');
+        Route::get('/quote-tester', fn() => view('rates::admin.quote.tester'))->name('admin.quote.tester');
+    });

--- a/src/config/orders.php
+++ b/src/config/orders.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'status_enum' => [
+        'pending','paid','processing','done','refunded','failed'
+    ],
+];

--- a/src/config/rates.php
+++ b/src/config/rates.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'cache_ttl' => 300,
+    'default_rate_field' => 'usd_sell',
+    'service_overrides' => [
+        // 'giftcard' => 'usd_buy',
+    ],
+];

--- a/src/database/migrations/2025_08_11_130000_create_rates_table.php
+++ b/src/database/migrations/2025_08_11_130000_create_rates_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('rates', function (Blueprint $t) {
+            $t->id();
+            $t->string('base_currency')->default('IRR');
+            $t->decimal('usd_buy', 18, 4);
+            $t->decimal('usd_sell', 18, 4);
+            $t->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rates');
+    }
+};

--- a/src/database/migrations/2025_08_11_130100_create_fee_rules_table.php
+++ b/src/database/migrations/2025_08_11_130100_create_fee_rules_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('fee_rules', function (Blueprint $t) {
+            $t->id();
+            $t->string('service_key');
+            $t->decimal('from_amount', 18, 2);
+            $t->decimal('to_amount', 18, 2);
+            $t->enum('fee_type', ['fixed','percent']);
+            $t->decimal('value', 18, 4);
+            $t->boolean('is_active')->default(true);
+            $t->timestamps();
+            $t->index(['service_key','from_amount','to_amount']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fee_rules');
+    }
+};

--- a/src/database/migrations/2025_08_11_130200_create_orders_table.php
+++ b/src/database/migrations/2025_08_11_130200_create_orders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $t) {
+            $t->id();
+            $t->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $t->string('service_key');
+            $t->string('currency')->default('USD');
+            $t->decimal('amount_usd', 18, 2);
+            $t->decimal('fee_usd', 18, 4);
+            $t->decimal('subtotal_usd', 18, 4);
+            $t->decimal('rate_used', 18, 4);
+            $t->decimal('total_irr', 20, 2);
+            $t->json('meta')->nullable();
+            $t->json('quote_breakdown');
+            $t->string('status');
+            $t->timestamps();
+            $t->index(['service_key','status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/src/database/migrations/2025_08_11_130300_create_order_items_table.php
+++ b/src/database/migrations/2025_08_11_130300_create_order_items_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('order_items', function (Blueprint $t) {
+            $t->id();
+            $t->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
+            $t->string('sku')->nullable();
+            $t->string('title');
+            $t->decimal('unit_price_usd', 18, 4);
+            $t->integer('qty')->default(1);
+            $t->decimal('line_total_usd', 18, 4);
+            $t->json('meta')->nullable();
+            $t->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('order_items');
+    }
+};

--- a/src/resources/views/components/admin/card.blade.php
+++ b/src/resources/views/components/admin/card.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes->merge(['class' => 'bg-white shadow rounded p-4']) }}>
+    {{ $slot }}
+</div>

--- a/src/storage/.gitignore
+++ b/src/storage/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/storage/framework/.gitignore
+++ b/src/storage/framework/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/tests/Unit/CalculateQuoteTest.php
+++ b/src/tests/Unit/CalculateQuoteTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Rates\Application\DTOs\QuoteInput;
+use App\Modules\Rates\Application\UseCases\CalculateQuote;
+use App\Modules\Rates\Domain\Entities\Rate;
+use App\Modules\Rates\Domain\Repositories\RateRepositoryInterface;
+use App\Modules\Rates\Domain\Services\FeeEngineInterface;
+use Tests\TestCase;
+
+class CalculateQuoteTest extends TestCase
+{
+    public function test_calculates_quote(): void
+    {
+        $rates = new class implements RateRepositoryInterface {
+            public function latest(): ?Rate { return new Rate('IRR', '600000', '610000'); }
+            public function upsert(Rate $rate): Rate { return $rate; }
+        };
+
+        $fees = new class implements FeeEngineInterface {
+            public function compute(string $serviceKey, string $amountUsd): string { return '5'; }
+        };
+
+        $useCase = new CalculateQuote($rates, $fees);
+        $result = $useCase(new QuoteInput('payforme', '10'));
+
+        $this->assertSame('10', $result->amountUsd);
+        $this->assertSame('5', $result->feeUsd);
+        $this->assertSame('15.0000', $result->subtotalUsd);
+        $this->assertSame('610000', $result->rateUsed);
+        $this->assertEquals(9150000, $result->totalIrr);
+    }
+}

--- a/src/tests/Unit/FeeEngineTest.php
+++ b/src/tests/Unit/FeeEngineTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Rates\Domain\Entities\FeeRule;
+use App\Modules\Rates\Domain\Enums\FeeType;
+use App\Modules\Rates\Domain\Repositories\FeeRuleRepositoryInterface;
+use App\Modules\Rates\Infrastructure\Services\FeeEngine;
+use PHPUnit\Framework\TestCase;
+
+class FeeEngineTest extends TestCase
+{
+    private function repo(array $rules): FeeRuleRepositoryInterface
+    {
+        return new class($rules) implements FeeRuleRepositoryInterface {
+            public function __construct(private array $rules) {}
+            public function forService(string $serviceKey): array { return $this->rules[$serviceKey] ?? []; }
+            public function upsert(FeeRule $rule): FeeRule { return $rule; }
+        };
+    }
+
+    public function test_fixed_fee(): void
+    {
+        $rule = new FeeRule('pay', '0', '100', FeeType::Fixed, '5');
+        $engine = new FeeEngine($this->repo(['pay' => [$rule]]));
+        $this->assertSame('5', $engine->compute('pay', '50'));
+    }
+
+    public function test_percent_fee(): void
+    {
+        $rule = new FeeRule('gift', '0', '100', FeeType::Percent, '10');
+        $engine = new FeeEngine($this->repo(['gift' => [$rule]]));
+        $this->assertSame('5.0000', $engine->compute('gift', '50'));
+    }
+
+    public function test_inactive_rule_returns_zero(): void
+    {
+        $rule = new FeeRule('pay', '0', '100', FeeType::Fixed, '5', false);
+        $engine = new FeeEngine($this->repo(['pay' => [$rule]]));
+        $this->assertSame('0', $engine->compute('pay', '50'));
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Rates module with fee rules, caching and quote calculation
- introduce Orders module with order creation use case
- add migrations, configs, basic admin views and unit tests

## Testing
- `php artisan test --testsuite=Unit`

------
https://chatgpt.com/codex/tasks/task_e_689a21030a588326bc5c472011e22744