### PR TITLE
feat: add pay-for-me module

### DIFF
--- a/src/app/Modules/PayForMe/.dev/migrate-module
+++ b/src/app/Modules/PayForMe/.dev/migrate-module
@@ -1,0 +1,2 @@
+#!/bin/bash
+php artisan migrate --path=app/Modules/PayForMe/Database/Migrations --realpath "$@"

--- a/src/app/Modules/PayForMe/.dev/test-module
+++ b/src/app/Modules/PayForMe/.dev/test-module
@@ -1,0 +1,2 @@
+#!/bin/bash
+php artisan test --filter PayForMe

--- a/src/app/Modules/PayForMe/Application/DTOs/CreateRequestInput.php
+++ b/src/app/Modules/PayForMe/Application/DTOs/CreateRequestInput.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\PayForMe\Application\DTOs;
+
+use Illuminate\Http\UploadedFile;
+
+class CreateRequestInput
+{
+    /** @param UploadedFile[] $attachments */
+    public function __construct(
+        public int $user_id,
+        public string $target_url,
+        public float $amount_usd,
+        public ?string $notes,
+        public array $attachments = [],
+    ) {
+    }
+}

--- a/src/app/Modules/PayForMe/Application/DTOs/QuoteDto.php
+++ b/src/app/Modules/PayForMe/Application/DTOs/QuoteDto.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Modules\PayForMe\Application\DTOs;
+
+class QuoteDto
+{
+    public function __construct(
+        public float $amount_usd,
+        public float $fee_usd,
+        public float $subtotal_usd,
+        public float $rate_used,
+        public float $total_irr,
+    ) {
+    }
+}

--- a/src/app/Modules/PayForMe/Application/DTOs/RequestView.php
+++ b/src/app/Modules/PayForMe/Application/DTOs/RequestView.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Modules\PayForMe\Application\DTOs;
+
+use App\Modules\PayForMe\Domain\Enums\PayForMeStatus;
+
+class RequestView
+{
+    public function __construct(
+        public int $id,
+        public string $request_code,
+        public float $amount_usd,
+        public float $total_irr,
+        public PayForMeStatus $status,
+    ) {
+    }
+}

--- a/src/app/Modules/PayForMe/Application/Services/Quote/QuoteCalculator.php
+++ b/src/app/Modules/PayForMe/Application/Services/Quote/QuoteCalculator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Modules\PayForMe\Application\Services\Quote;
+
+use App\Modules\PayForMe\Application\DTOs\QuoteDto;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\App;
+
+class QuoteCalculator
+{
+    public function calculate(string $serviceKey, float $amountUsd): QuoteDto
+    {
+        if (class_exists('App\\Modules\\Rates\\Application\\UseCases\\CalculateQuote')) {
+            $calc = App::make('App\\Modules\\Rates\\Application\\UseCases\\CalculateQuote');
+            $result = $calc->execute($serviceKey, $amountUsd);
+            return new QuoteDto(
+                $result->amount_usd,
+                $result->fee_usd,
+                $result->subtotal_usd,
+                $result->rate_used,
+                $result->total_irr
+            );
+        }
+
+        $config = Config::get('payforme.quote.stub');
+        $rate = $config['usd_sell'];
+        $feeRules = $config['fee_rules'];
+        $fee = 0;
+        foreach ($feeRules as $rule) {
+            if ($amountUsd >= $rule['from'] && $amountUsd < $rule['to']) {
+                if ($rule['type'] === 'percent') {
+                    $fee = $amountUsd * ($rule['value'] / 100);
+                } else {
+                    $fee = $rule['value'];
+                }
+                break;
+            }
+        }
+        $subtotal = $amountUsd + $fee;
+        $totalIrr = round($subtotal * $rate);
+        return new QuoteDto($amountUsd, $fee, $subtotal, $rate, $totalIrr);
+    }
+}

--- a/src/app/Modules/PayForMe/Application/UseCases/Admin/UpdateStatus.php
+++ b/src/app/Modules/PayForMe/Application/UseCases/Admin/UpdateStatus.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Modules\PayForMe\Application\UseCases\Admin;
+
+use App\Modules\PayForMe\Domain\Repositories\PayForMeRepositoryInterface;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+class UpdateStatus
+{
+    public function __construct(protected PayForMeRepositoryInterface $repo)
+    {
+    }
+
+    public function execute(int $id, string $status, ?string $note = null, ?array $attachment = null): void
+    {
+        $validator = Validator::make([
+            'status' => $status,
+            'note' => $note,
+        ], [
+            'status' => 'required|in:paid,processing,done,refunded,failed',
+            'note' => 'nullable|max:2000',
+        ]);
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+        if ($note) {
+            $note = now().' '.(Auth::user()->email ?? 'admin').": $note";
+        }
+        $this->repo->updateStatus($id, $status, $note, $attachment);
+    }
+}

--- a/src/app/Modules/PayForMe/Application/UseCases/CreateRequest.php
+++ b/src/app/Modules/PayForMe/Application/UseCases/CreateRequest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Modules\PayForMe\Application\UseCases;
+
+use App\Modules\PayForMe\Application\DTOs\CreateRequestInput;
+use App\Modules\PayForMe\Application\DTOs\RequestView;
+use App\Modules\PayForMe\Application\Services\Quote\QuoteCalculator;
+use App\Modules\PayForMe\Domain\Enums\PayForMeStatus;
+use App\Modules\PayForMe\Domain\Repositories\PayForMeRepositoryInterface;
+use App\Modules\PayForMe\Infrastructure\Storage\Attachments\AttachmentHelper;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+class CreateRequest
+{
+    public function __construct(
+        protected PayForMeRepositoryInterface $repo,
+        protected QuoteCalculator $calculator,
+    ) {
+    }
+
+    public function execute(CreateRequestInput $input): RequestView
+    {
+        $this->validate($input);
+        $attachments = [];
+        foreach ($input->attachments as $file) {
+            $attachments[] = AttachmentHelper::store($file);
+        }
+
+        $quote = $this->calculator->calculate('payforme', $input->amount_usd);
+
+        $requestCode = 'PF-'.now()->format('Ymd').'-'.Str::upper(Str::random(4));
+
+        $data = [
+            'user_id' => $input->user_id,
+            'request_code' => $requestCode,
+            'target_url' => $this->sanitizeUrl($input->target_url),
+            'amount_usd' => $input->amount_usd,
+            'notes' => $input->notes,
+            'attachments' => $attachments,
+            'quote_snapshot' => [
+                'amount_usd' => $quote->amount_usd,
+                'fee_usd' => $quote->fee_usd,
+                'subtotal_usd' => $quote->subtotal_usd,
+                'rate_used' => $quote->rate_used,
+                'total_irr' => $quote->total_irr,
+            ],
+            'status' => PayForMeStatus::Pending->value,
+        ];
+
+        $entity = $this->repo->create($data);
+
+        return new RequestView(
+            $entity->id,
+            $entity->request_code,
+            $entity->amount_usd,
+            $quote->total_irr,
+            $entity->status,
+        );
+    }
+
+    protected function validate(CreateRequestInput $input): void
+    {
+        $validator = Validator::make([
+            'target_url' => $input->target_url,
+            'amount_usd' => $input->amount_usd,
+            'notes' => $input->notes,
+            'attachments' => $input->attachments,
+        ], [
+            'target_url' => 'required|url|max:1024',
+            'amount_usd' => 'required|numeric|min:1|max:100000',
+            'notes' => 'nullable|max:2000',
+            'attachments.*' => 'file|mimes:jpg,png,webp,pdf|max:5120',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    protected function sanitizeUrl(string $url): string
+    {
+        $parts = parse_url($url);
+        $scheme = $parts['scheme'] ?? 'http';
+        $host = $parts['host'] ?? '';
+        $path = $parts['path'] ?? '';
+        $query = '';
+        if (!empty($parts['query'])) {
+            parse_str($parts['query'], $params);
+            $params = array_filter($params, fn($v, $k) => !str_starts_with($k, 'utm_'), ARRAY_FILTER_USE_BOTH);
+            if ($params) {
+                $query = '?'.http_build_query($params);
+            }
+        }
+        return $scheme.'://'.$host.$path.$query;
+    }
+}

--- a/src/app/Modules/PayForMe/Application/UseCases/GetMyRequests.php
+++ b/src/app/Modules/PayForMe/Application/UseCases/GetMyRequests.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Modules\PayForMe\Application\UseCases;
+
+use App\Modules\PayForMe\Application\DTOs\RequestView;
+use App\Modules\PayForMe\Domain\Repositories\PayForMeRepositoryInterface;
+
+class GetMyRequests
+{
+    public function __construct(protected PayForMeRepositoryInterface $repo)
+    {
+    }
+
+    public function execute(int $userId, int $perPage = 15)
+    {
+        $paginator = $this->repo->findByUser($userId, $perPage);
+        $paginator->getCollection()->transform(function ($model) {
+            return new RequestView(
+                $model->id,
+                $model->request_code,
+                $model->amount_usd,
+                $model->quote_snapshot['total_irr'] ?? 0,
+                $model->status
+            );
+        });
+        return $paginator;
+    }
+}

--- a/src/app/Modules/PayForMe/Database/Migrations/2025_08_11_140000_create_payforme_requests_table.php
+++ b/src/app/Modules/PayForMe/Database/Migrations/2025_08_11_140000_create_payforme_requests_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payforme_requests', function (Blueprint $t) {
+            $t->id();
+            $t->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $t->string('request_code')->unique();
+            $t->string('target_url');
+            $t->decimal('amount_usd', 18, 2);
+            $t->text('notes')->nullable();
+            $t->json('attachments')->nullable();
+            $t->json('quote_snapshot')->nullable();
+            $t->unsignedBigInteger('order_id')->nullable();
+            $t->string('status');
+            $t->timestamps();
+            $t->index(['user_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payforme_requests');
+    }
+};

--- a/src/app/Modules/PayForMe/Domain/Entities/PayForMeRequest.php
+++ b/src/app/Modules/PayForMe/Domain/Entities/PayForMeRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Modules\PayForMe\Domain\Entities;
+
+use App\Modules\PayForMe\Domain\Enums\PayForMeStatus;
+
+class PayForMeRequest
+{
+    public function __construct(
+        public int $id,
+        public int $user_id,
+        public string $request_code,
+        public string $target_url,
+        public float $amount_usd,
+        public ?string $notes,
+        public array $attachments,
+        public array $quote_snapshot,
+        public ?int $order_id,
+        public PayForMeStatus $status,
+    ) {
+    }
+}

--- a/src/app/Modules/PayForMe/Domain/Enums/PayForMeStatus.php
+++ b/src/app/Modules/PayForMe/Domain/Enums/PayForMeStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\PayForMe\Domain\Enums;
+
+enum PayForMeStatus: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Processing = 'processing';
+    case Done = 'done';
+    case Refunded = 'refunded';
+    case Failed = 'failed';
+}

--- a/src/app/Modules/PayForMe/Domain/Repositories/PayForMeRepositoryInterface.php
+++ b/src/app/Modules/PayForMe/Domain/Repositories/PayForMeRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Modules\PayForMe\Domain\Repositories;
+
+use App\Modules\PayForMe\Domain\Entities\PayForMeRequest;
+
+interface PayForMeRepositoryInterface
+{
+    public function create(array $data): PayForMeRequest;
+
+    public function findByUser(int $userId, int $perPage = 15);
+
+    public function find(int $id): ?PayForMeRequest;
+
+    public function updateStatus(int $id, string $status, ?string $note = null, ?array $attachment = null): void;
+}

--- a/src/app/Modules/PayForMe/Http/Controllers/Admin/RequestController.php
+++ b/src/app/Modules/PayForMe/Http/Controllers/Admin/RequestController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Modules\PayForMe\Http\Controllers\Admin;
+
+use App\Modules\PayForMe\Application\UseCases\Admin\UpdateStatus;
+use App\Modules\PayForMe\Infrastructure\Persistence\Eloquent\Models\PayForMeRequestModel;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class RequestController extends Controller
+{
+    public function __construct(protected UpdateStatus $updateStatus)
+    {
+    }
+
+    public function index()
+    {
+        $requests = PayForMeRequestModel::latest()->paginate();
+        return view('payforme::admin.index', compact('requests'));
+    }
+
+    public function show($id)
+    {
+        $request = PayForMeRequestModel::findOrFail($id);
+        return view('payforme::admin.show', compact('request'));
+    }
+
+    public function updateStatus($id, Request $request)
+    {
+        $attachment = null;
+        if ($request->hasFile('receipt')) {
+            $attachment = \App\Modules\PayForMe\Infrastructure\Storage\Attachments\AttachmentHelper::store($request->file('receipt'));
+        }
+        $this->updateStatus->execute($id, $request->input('status'), $request->input('note'), $attachment);
+        return redirect()->back();
+    }
+}

--- a/src/app/Modules/PayForMe/Http/Controllers/LandingController.php
+++ b/src/app/Modules/PayForMe/Http/Controllers/LandingController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Modules\PayForMe\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+
+class LandingController extends Controller
+{
+    public function index()
+    {
+        return view('payforme::public.landing');
+    }
+}

--- a/src/app/Modules/PayForMe/Http/Controllers/My/RequestController.php
+++ b/src/app/Modules/PayForMe/Http/Controllers/My/RequestController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Modules\PayForMe\Http\Controllers\My;
+
+use App\Modules\PayForMe\Application\UseCases\GetMyRequests;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+
+class RequestController extends Controller
+{
+    public function __construct(protected GetMyRequests $getMyRequests)
+    {
+    }
+
+    public function index()
+    {
+        $requests = $this->getMyRequests->execute(Auth::id());
+        return view('payforme::my.index', compact('requests'));
+    }
+}

--- a/src/app/Modules/PayForMe/Http/Controllers/RequestController.php
+++ b/src/app/Modules/PayForMe/Http/Controllers/RequestController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\PayForMe\Http\Controllers;
+
+use App\Modules\PayForMe\Application\DTOs\CreateRequestInput;
+use App\Modules\PayForMe\Application\UseCases\CreateRequest;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+
+class RequestController extends Controller
+{
+    public function __construct(protected CreateRequest $createRequest)
+    {
+    }
+
+    public function create()
+    {
+        return view('payforme::public.form');
+    }
+
+    public function store(Request $request)
+    {
+        $input = new CreateRequestInput(
+            Auth::id(),
+            $request->input('target_url'),
+            (float) $request->input('amount_usd'),
+            $request->input('notes'),
+            $request->file('attachments', [])
+        );
+        $view = $this->createRequest->execute($input);
+        return redirect()->route('payforme.landing')->with('request_code', $view->request_code);
+    }
+}

--- a/src/app/Modules/PayForMe/Infrastructure/Persistence/Eloquent/Models/PayForMeRequestModel.php
+++ b/src/app/Modules/PayForMe/Infrastructure/Persistence/Eloquent/Models/PayForMeRequestModel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Modules\PayForMe\Infrastructure\Persistence\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PayForMeRequestModel extends Model
+{
+    protected $table = 'payforme_requests';
+
+    protected $fillable = [
+        'user_id', 'request_code', 'target_url', 'amount_usd',
+        'notes', 'attachments', 'quote_snapshot', 'order_id', 'status'
+    ];
+
+    protected $casts = [
+        'attachments' => 'array',
+        'quote_snapshot' => 'array',
+        'amount_usd' => 'float',
+    ];
+}

--- a/src/app/Modules/PayForMe/Infrastructure/Persistence/Eloquent/Repositories/PayForMeRepository.php
+++ b/src/app/Modules/PayForMe/Infrastructure/Persistence/Eloquent/Repositories/PayForMeRepository.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Modules\PayForMe\Infrastructure\Persistence\Eloquent\Repositories;
+
+use App\Modules\PayForMe\Domain\Entities\PayForMeRequest;
+use App\Modules\PayForMe\Domain\Enums\PayForMeStatus;
+use App\Modules\PayForMe\Domain\Repositories\PayForMeRepositoryInterface;
+use App\Modules\PayForMe\Infrastructure\Persistence\Eloquent\Models\PayForMeRequestModel;
+
+class PayForMeRepository implements PayForMeRepositoryInterface
+{
+    public function create(array $data): PayForMeRequest
+    {
+        $model = PayForMeRequestModel::create($data);
+        return $this->toEntity($model);
+    }
+
+    public function findByUser(int $userId, int $perPage = 15)
+    {
+        return PayForMeRequestModel::where('user_id', $userId)->paginate($perPage);
+    }
+
+    public function find(int $id): ?PayForMeRequest
+    {
+        $model = PayForMeRequestModel::find($id);
+        return $model ? $this->toEntity($model) : null;
+    }
+
+    public function updateStatus(int $id, string $status, ?string $note = null, ?array $attachment = null): void
+    {
+        $model = PayForMeRequestModel::findOrFail($id);
+        if ($note) {
+            $notes = ($model->notes ? $model->notes . "\n" : '') . $note;
+            $model->notes = $notes;
+        }
+        if ($attachment) {
+            $attachments = $model->attachments ?: [];
+            $attachments[] = $attachment;
+            $model->attachments = $attachments;
+        }
+        $model->status = $status;
+        $model->save();
+    }
+
+    protected function toEntity(PayForMeRequestModel $model): PayForMeRequest
+    {
+        return new PayForMeRequest(
+            $model->id,
+            $model->user_id,
+            $model->request_code,
+            $model->target_url,
+            $model->amount_usd,
+            $model->notes,
+            $model->attachments ?: [],
+            $model->quote_snapshot ?: [],
+            $model->order_id,
+            PayForMeStatus::from($model->status)
+        );
+    }
+}

--- a/src/app/Modules/PayForMe/Infrastructure/Storage/Attachments/AttachmentHelper.php
+++ b/src/app/Modules/PayForMe/Infrastructure/Storage/Attachments/AttachmentHelper.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Modules\PayForMe\Infrastructure\Storage\Attachments;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+class AttachmentHelper
+{
+    public static function store(UploadedFile $file): array
+    {
+        $path = $file->store('payforme/'.date('Y/m/d'), 'public');
+        return [
+            'path' => $path,
+            'name' => $file->getClientOriginalName(),
+            'size' => $file->getSize(),
+            'type' => $file->getMimeType(),
+        ];
+    }
+}

--- a/src/app/Modules/PayForMe/Livewire/Admin/RequestShow.php
+++ b/src/app/Modules/PayForMe/Livewire/Admin/RequestShow.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Modules\PayForMe\Livewire\Admin;
+
+use App\Modules\PayForMe\Application\UseCases\Admin\UpdateStatus;
+use App\Modules\PayForMe\Infrastructure\Persistence\Eloquent\Models\PayForMeRequestModel;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class RequestShow extends Component
+{
+    use WithFileUploads;
+
+    public PayForMeRequestModel $request;
+    public string $status;
+    public ?string $note = null;
+    public $receipt;
+
+    public function mount($id)
+    {
+        $this->request = PayForMeRequestModel::findOrFail($id);
+        $this->status = $this->request->status;
+    }
+
+    public function updateStatus(UpdateStatus $updateStatus)
+    {
+        $attachment = null;
+        if ($this->receipt) {
+            $attachment = \App\Modules\PayForMe\Infrastructure\Storage\Attachments\AttachmentHelper::store($this->receipt);
+        }
+        $updateStatus->execute($this->request->id, $this->status, $this->note, $attachment);
+        $this->request->refresh();
+    }
+
+    public function render()
+    {
+        return view('payforme::admin.request-show');
+    }
+}

--- a/src/app/Modules/PayForMe/Livewire/Admin/RequestsTable.php
+++ b/src/app/Modules/PayForMe/Livewire/Admin/RequestsTable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\PayForMe\Livewire\Admin;
+
+use App\Modules\PayForMe\Infrastructure\Persistence\Eloquent\Models\PayForMeRequestModel;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class RequestsTable extends Component
+{
+    use WithPagination;
+
+    public string $status = '';
+
+    public function render()
+    {
+        $query = PayForMeRequestModel::query();
+        if ($this->status) {
+            $query->where('status', $this->status);
+        }
+        $requests = $query->paginate();
+        return view('payforme::admin.requests-table', ['requests' => $requests]);
+    }
+}

--- a/src/app/Modules/PayForMe/Livewire/My/RequestsTable.php
+++ b/src/app/Modules/PayForMe/Livewire/My/RequestsTable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Modules\PayForMe\Livewire\My;
+
+use App\Modules\PayForMe\Application\UseCases\GetMyRequests;
+use Livewire\Component;
+use Livewire\WithPagination;
+use Illuminate\Support\Facades\Auth;
+
+class RequestsTable extends Component
+{
+    use WithPagination;
+
+    public function render(GetMyRequests $useCase)
+    {
+        $requests = $useCase->execute(Auth::id());
+        return view('payforme::my.requests-table', ['requests' => $requests]);
+    }
+}

--- a/src/app/Modules/PayForMe/Livewire/Public/QuoteWidget.php
+++ b/src/app/Modules/PayForMe/Livewire/Public/QuoteWidget.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Modules\PayForMe\Livewire\Public;
+
+use App\Modules\PayForMe\Application\Services\Quote\QuoteCalculator;
+use Livewire\Component;
+
+class QuoteWidget extends Component
+{
+    public string $serviceKey = 'payforme';
+    public $amountUsd = 0;
+    public ?array $quote = null;
+
+    public function updatedAmountUsd()
+    {
+        $calc = app(QuoteCalculator::class);
+        $dto = $calc->calculate($this->serviceKey, (float) $this->amountUsd);
+        $this->quote = [
+            'amount_usd' => $dto->amount_usd,
+            'fee_usd' => $dto->fee_usd,
+            'subtotal_usd' => $dto->subtotal_usd,
+            'rate_used' => $dto->rate_used,
+            'total_irr' => $dto->total_irr,
+        ];
+    }
+
+    public function render()
+    {
+        return view('payforme::public.quote-widget');
+    }
+}

--- a/src/app/Modules/PayForMe/Livewire/Public/RequestForm.php
+++ b/src/app/Modules/PayForMe/Livewire/Public/RequestForm.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\PayForMe\Livewire\Public;
+
+use App\Modules\PayForMe\Application\DTOs\CreateRequestInput;
+use App\Modules\PayForMe\Application\UseCases\CreateRequest;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use Illuminate\Support\Facades\Auth;
+
+class RequestForm extends Component
+{
+    use WithFileUploads;
+
+    public string $target_url = '';
+    public $amount_usd = 0;
+    public ?string $notes = null;
+    public array $attachments = [];
+
+    public ?string $request_code = null;
+
+    public function submit(CreateRequest $createRequest)
+    {
+        $input = new CreateRequestInput(Auth::id(), $this->target_url, (float)$this->amount_usd, $this->notes, $this->attachments);
+        $view = $createRequest->execute($input);
+        $this->request_code = $view->request_code;
+        $this->reset(['target_url','amount_usd','notes','attachments']);
+    }
+
+    public function render()
+    {
+        return view('payforme::public.form-livewire');
+    }
+}

--- a/src/app/Modules/PayForMe/PayForMeServiceProvider.php
+++ b/src/app/Modules/PayForMe/PayForMeServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\PayForMe;
+
+use Illuminate\Support\ServiceProvider;
+use App\Modules\PayForMe\Domain\Repositories\PayForMeRepositoryInterface;
+use App\Modules\PayForMe\Infrastructure\Persistence\Eloquent\Repositories\PayForMeRepository;
+
+class PayForMeServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/config.php', 'payforme');
+        $this->app->bind(PayForMeRepositoryInterface::class, PayForMeRepository::class);
+    }
+
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/routes/web.php');
+        $this->loadRoutesFrom(__DIR__.'/routes/admin.php');
+        $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
+        $this->loadViewsFrom(__DIR__.'/Views', 'payforme');
+    }
+}

--- a/src/app/Modules/PayForMe/README.md
+++ b/src/app/Modules/PayForMe/README.md
@@ -1,0 +1,17 @@
+# PayForMe Module
+
+This module provides Pay-For-Me service allowing users to request foreign payments.
+
+## Local enable
+
+Add `App\Modules\PayForMe\PayForMeServiceProvider::class` to the `ModulesServiceProvider` providers array locally (do not commit).
+
+Run migrations:
+
+```
+php artisan migrate --path=app/Modules/PayForMe/Database/Migrations --realpath
+```
+
+Access via `/modules/payforme/request`.
+
+Configure quote stub via `config('payforme.quote.stub')` or tinker.

--- a/src/app/Modules/PayForMe/Views/admin/index.blade.php
+++ b/src/app/Modules/PayForMe/Views/admin/index.blade.php
@@ -1,0 +1,3 @@
+<x-payforme::layouts.module>
+    @livewire('App\\Modules\\PayForMe\\Livewire\\Admin\\RequestsTable')
+</x-payforme::layouts.module>

--- a/src/app/Modules/PayForMe/Views/admin/request-show.blade.php
+++ b/src/app/Modules/PayForMe/Views/admin/request-show.blade.php
@@ -1,0 +1,18 @@
+<div>
+    <h2 class="text-xl mb-4">Request {{ $request->request_code }}</h2>
+    <div>Status: {{ $request->status }}</div>
+    <div class="mt-4">
+        <form wire:submit.prevent="updateStatus" class="space-y-2">
+            <select wire:model="status" class="border p-2">
+                <option value="paid">paid</option>
+                <option value="processing">processing</option>
+                <option value="done">done</option>
+                <option value="refunded">refunded</option>
+                <option value="failed">failed</option>
+            </select>
+            <textarea wire:model="note" class="border p-2 w-full" placeholder="Internal note"></textarea>
+            <input type="file" wire:model="receipt">
+            <button class="bg-blue-500 text-white px-4 py-2">Update</button>
+        </form>
+    </div>
+</div>

--- a/src/app/Modules/PayForMe/Views/admin/requests-table.blade.php
+++ b/src/app/Modules/PayForMe/Views/admin/requests-table.blade.php
@@ -1,0 +1,11 @@
+<div>
+    <table class="min-w-full">
+        <thead><tr><th>ID</th><th>User</th><th>Code</th><th>Status</th></tr></thead>
+        <tbody>
+        @foreach($requests as $r)
+            <tr class="border-t"><td>{{ $r->id }}</td><td>{{ $r->user_id }}</td><td><a href="{{ route('payforme.admin.show', $r->id) }}" class="text-blue-500">{{ $r->request_code }}</a></td><td>{{ $r->status }}</td></tr>
+        @endforeach
+        </tbody>
+    </table>
+    {{ $requests->links() }}
+</div>

--- a/src/app/Modules/PayForMe/Views/admin/show.blade.php
+++ b/src/app/Modules/PayForMe/Views/admin/show.blade.php
@@ -1,0 +1,3 @@
+<x-payforme::layouts.module>
+    @livewire('App\\Modules\\PayForMe\\Livewire\\Admin\\RequestShow', ['id' => $request->id])
+</x-payforme::layouts.module>

--- a/src/app/Modules/PayForMe/Views/layouts/module.blade.php
+++ b/src/app/Modules/PayForMe/Views/layouts/module.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PayForMe</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
+</head>
+<body class="p-4">
+<div class="container mx-auto">
+    {{ $slot }}
+</div>
+</body>
+</html>

--- a/src/app/Modules/PayForMe/Views/my/index.blade.php
+++ b/src/app/Modules/PayForMe/Views/my/index.blade.php
@@ -1,0 +1,3 @@
+<x-payforme::layouts.module>
+    @livewire('App\\Modules\\PayForMe\\Livewire\\My\\RequestsTable')
+</x-payforme::layouts.module>

--- a/src/app/Modules/PayForMe/Views/my/requests-table.blade.php
+++ b/src/app/Modules/PayForMe/Views/my/requests-table.blade.php
@@ -1,0 +1,11 @@
+<div>
+    <table class="min-w-full">
+        <thead><tr><th>Code</th><th>Amount</th><th>Total IRR</th><th>Status</th></tr></thead>
+        <tbody>
+        @foreach($requests as $r)
+            <tr class="border-t"><td>{{ $r->request_code }}</td><td>{{ $r->amount_usd }}</td><td>{{ $r->quote_snapshot['total_irr'] ?? '' }}</td><td>{{ $r->status }}</td></tr>
+        @endforeach
+        </tbody>
+    </table>
+    {{ $requests->links() }}
+</div>

--- a/src/app/Modules/PayForMe/Views/public/form-livewire.blade.php
+++ b/src/app/Modules/PayForMe/Views/public/form-livewire.blade.php
@@ -1,0 +1,24 @@
+<x-payforme::layouts.module>
+    <form wire:submit.prevent="submit" class="space-y-4">
+        <div>
+            <label>Target URL</label>
+            <input type="url" wire:model="target_url" class="border p-2 w-full">
+        </div>
+        <div>
+            <label>Amount (USD)</label>
+            <input type="number" step="0.01" wire:model.debounce.500ms="amount_usd" class="border p-2 w-full">
+        </div>
+        <div>
+            <label>Notes</label>
+            <textarea wire:model="notes" class="border p-2 w-full"></textarea>
+        </div>
+        <div>
+            <input type="file" wire:model="attachments" multiple>
+        </div>
+        @livewire('App\\Modules\\PayForMe\\Livewire\\Public\\QuoteWidget', ['amountUsd' => \$amount_usd])
+        <button class="bg-blue-500 text-white px-4 py-2">Submit</button>
+        @if($request_code)
+            <div class="text-green-600 mt-2">Request Code: {{ $request_code }}</div>
+        @endif
+    </form>
+</x-payforme::layouts.module>

--- a/src/app/Modules/PayForMe/Views/public/form.blade.php
+++ b/src/app/Modules/PayForMe/Views/public/form.blade.php
@@ -1,0 +1,25 @@
+<x-payforme::layouts.module>
+    <form action="{{ route('payforme.request.store') }}" method="POST" enctype="multipart/form-data" class="space-y-4">
+        @csrf
+        <div>
+            <label>Target URL</label>
+            <input type="url" name="target_url" class="border p-2 w-full" required>
+        </div>
+        <div>
+            <label>Amount (USD)</label>
+            <input type="number" step="0.01" name="amount_usd" class="border p-2 w-full" required>
+        </div>
+        <div>
+            <label>Notes</label>
+            <textarea name="notes" class="border p-2 w-full"></textarea>
+        </div>
+        <div>
+            <label>Attachments</label>
+            <input type="file" name="attachments[]" multiple class="border p-2 w-full">
+        </div>
+        <div>
+            @livewire('App\\Modules\\PayForMe\\Livewire\\Public\\QuoteWidget')
+        </div>
+        <button class="bg-blue-500 text-white px-4 py-2">Submit</button>
+    </form>
+</x-payforme::layouts.module>

--- a/src/app/Modules/PayForMe/Views/public/landing.blade.php
+++ b/src/app/Modules/PayForMe/Views/public/landing.blade.php
@@ -1,0 +1,10 @@
+<x-payforme::layouts.module>
+    <div class="bg-white p-6 rounded shadow">
+        <h1 class="text-2xl mb-4">Pay For Me</h1>
+        <p>Request us to pay for a purchase on your behalf.</p>
+        @if(session('request_code'))
+            <div class="mt-4 text-green-600">Request Code: {{ session('request_code') }}</div>
+        @endif
+        <a href="{{ route('payforme.request.create') }}" class="text-blue-500">Create Request</a>
+    </div>
+</x-payforme::layouts.module>

--- a/src/app/Modules/PayForMe/Views/public/quote-widget.blade.php
+++ b/src/app/Modules/PayForMe/Views/public/quote-widget.blade.php
@@ -1,0 +1,5 @@
+<div class="p-4 border rounded">
+    <div>Rate: {{ $quote['rate_used'] ?? '-' }}</div>
+    <div>Fee: {{ $quote['fee_usd'] ?? '-' }}</div>
+    <div>Total IRR: {{ $quote['total_irr'] ?? '-' }}</div>
+</div>

--- a/src/app/Modules/PayForMe/config.php
+++ b/src/app/Modules/PayForMe/config.php
@@ -1,0 +1,15 @@
+<?php
+return [
+    'routes_prefix' => 'modules/payforme',
+    'quote' => [
+        'use_stub' => true,
+        'stub' => [
+            'usd_sell' => 580000,
+            'fee_rules' => [
+                ['from' => 0, 'to' => 50, 'type' => 'percent', 'value' => 5],
+                ['from' => 50, 'to' => 200, 'type' => 'percent', 'value' => 3],
+                ['from' => 200, 'to' => 999999, 'type' => 'fixed', 'value' => 4],
+            ],
+        ],
+    ],
+];

--- a/src/app/Modules/PayForMe/routes/admin.php
+++ b/src/app/Modules/PayForMe/routes/admin.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Modules\PayForMe\Http\Controllers\Admin\RequestController as AdminRequestController;
+
+Route::middleware(['web','auth'])
+    ->prefix(config('payforme.routes_prefix').'/admin')
+    ->group(function () {
+        Route::get('/requests', [AdminRequestController::class, 'index'])->name('payforme.admin.index');
+        Route::get('/requests/{id}', [AdminRequestController::class, 'show'])->name('payforme.admin.show');
+        Route::post('/requests/{id}/status', [AdminRequestController::class, 'updateStatus'])->name('payforme.admin.status');
+    });

--- a/src/app/Modules/PayForMe/routes/web.php
+++ b/src/app/Modules/PayForMe/routes/web.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Modules\PayForMe\Http\Controllers\LandingController;
+use App\Modules\PayForMe\Http\Controllers\My\RequestController as MyRequestController;
+use App\Modules\PayForMe\Http\Controllers\RequestController;
+
+Route::middleware(['web','auth'])
+    ->prefix(config('payforme.routes_prefix'))
+    ->group(function () {
+        Route::get('/', [LandingController::class, 'index'])->name('payforme.landing');
+        Route::get('/request', [RequestController::class, 'create'])->name('payforme.request.create');
+        Route::post('/request', [RequestController::class, 'store'])->name('payforme.request.store');
+        Route::get('/my', [MyRequestController::class, 'index'])->name('payforme.my.index');
+    });

--- a/src/tests/PayForMe/PayForMeCreateRequestTest.php
+++ b/src/tests/PayForMe/PayForMeCreateRequestTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\PayForMe;
+
+use App\Modules\PayForMe\Application\DTOs\CreateRequestInput;
+use App\Modules\PayForMe\Application\UseCases\CreateRequest;
+use App\Modules\PayForMe\Infrastructure\Persistence\Eloquent\Repositories\PayForMeRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use App\Modules\PayForMe\Application\Services\Quote\QuoteCalculator;
+use App\Modules\PayForMe\PayForMeServiceProvider;
+
+class PayForMeCreateRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app()->register(PayForMeServiceProvider::class);
+        $this->artisan('migrate', ['--path' => 'app/Modules/PayForMe/Database/Migrations', '--realpath' => true]);
+        Storage::fake('public');
+    }
+
+    public function test_create_request_persists()
+    {
+        $user = \App\Models\User::factory()->create();
+        $input = new CreateRequestInput($user->id, 'https://example.com', 10, null, [UploadedFile::fake()->create('f.pdf',100)]);
+        $useCase = new CreateRequest(new PayForMeRepository(), new QuoteCalculator());
+        $view = $useCase->execute($input);
+        $this->assertNotEmpty($view->request_code);
+        $this->assertDatabaseHas('payforme_requests', ['request_code' => $view->request_code]);
+    }
+}

--- a/src/tests/PayForMe/PayForMeQuoteCalculatorTest.php
+++ b/src/tests/PayForMe/PayForMeQuoteCalculatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\PayForMe;
+
+use App\Modules\PayForMe\Application\Services\Quote\QuoteCalculator;
+use App\Modules\PayForMe\PayForMeServiceProvider;
+use Tests\TestCase;
+
+class PayForMeQuoteCalculatorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app()->register(PayForMeServiceProvider::class);
+    }
+
+    public function test_percent_rule_applied()
+    {
+        $calc = new QuoteCalculator();
+        $dto = $calc->calculate('payforme', 10);
+        $this->assertEquals(0.5, $dto->fee_usd);
+    }
+
+    public function test_fixed_rule_applied()
+    {
+        $calc = new QuoteCalculator();
+        $dto = $calc->calculate('payforme', 250);
+        $this->assertEquals(4, $dto->fee_usd);
+    }
+}

--- a/src/tests/PayForMe/PayForMeRequestFormFeatureTest.php
+++ b/src/tests/PayForMe/PayForMeRequestFormFeatureTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\PayForMe;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Modules\PayForMe\PayForMeServiceProvider;
+
+class PayForMeRequestFormFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app()->register(PayForMeServiceProvider::class);
+        $this->artisan('migrate', ['--path' => 'app/Modules/PayForMe/Database/Migrations', '--realpath' => true]);
+    }
+
+    public function test_get_form()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user)
+            ->get(route('payforme.request.create'))
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add PayForMe module with routes, service provider, and stub quote calculator
- support creating requests with attachments and stored quote snapshot
- provide basic tests for quote calculator and request creation

## Testing
- `./app/Modules/PayForMe/.dev/migrate-module --force`
- `./vendor/bin/phpunit tests/PayForMe` *(fails: Cannot redeclare class App\Modules\SharedKernel\Application\View\Components\Dialog)*

------
https://chatgpt.com/codex/tasks/task_e_689a224752e483269042f6c0a9e67a2f